### PR TITLE
Add config generator script and rewrite README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -163,3 +163,7 @@ results/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+# Claude Code
+CLAUDE.md
+.claude/

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ SHELL := /bin/bash
 .DEFAULT_GOAL := help
 
 # --- File sets ---------------------------------------------------------------
-PY_FILES   := workflow/rules/helpers.py
+PY_FILES   := workflow/rules/helpers.py scripts/generate_config.py
 SMK_FILES  := workflow/rules/*.smk workflow/Snakefile
 SH_FILES   := scripts/run_snakemake.sh
 

--- a/README.md
+++ b/README.md
@@ -1,53 +1,255 @@
 # sm-calling
 
-Snakemake 8+ variant calling pipeline for somatic (Mutect2) and germline
-(FreeBayes) analysis on HPC clusters.
+Snakemake 8+ variant calling pipeline for somatic (Mutect2) and germline (FreeBayes) analysis on SLURM HPC clusters.
 
-Part of the [scholl-lab](https://github.com/scholl-lab) bioinformatics suite.
+**Analysis-ready BAMs → scatter → call → gather → filter → VCF**
 
-## Quick Start
+Supports both **BIH HPC** and **Charite HPC** (auto-detected), plus local execution.
+
+Part of the [scholl-lab](https://github.com/scholl-lab) bioinformatics suite — designed to run after [sm-alignment](https://github.com/scholl-lab/sm-alignment).
+
+---
+
+## Setup
+
+### 1. Clone into your project directory
+
+The pipeline should live inside each project's directory on the cluster, not in your home directory (quota is too small for results).
 
 ```bash
-# 1. Install Snakemake 8+ and the SLURM executor plugin
-conda create -n snakemake -c conda-forge -c bioconda 'snakemake>=8.0'
-pip install snakemake-executor-plugin-slurm
+# Charite HPC
+cd /sc-projects/<your-project>
+git clone https://github.com/scholl-lab/sm-calling.git
+cd sm-calling
 
-# 2. Edit configuration
-cp config/config.yaml config/my_config.yaml   # customize paths
-vim config/samples.tsv                         # add your samples
-
-# 3. Run (auto-detects BIH / Charite / local)
-sbatch scripts/run_snakemake.sh config/my_config.yaml
+# BIH HPC
+cd /data/cephfs-1/work/projects/<your-project>
+git clone https://github.com/scholl-lab/sm-calling.git
+cd sm-calling
 ```
 
-## Supported Callers
+### 2. Install Snakemake 8+ and the SLURM executor plugin
 
-| Caller | Analysis Types | Output |
-|--------|---------------|--------|
-| **Mutect2** | tumor_only, tumor_normal | Filtered somatic VCFs per sample |
-| **FreeBayes** | germline | Merged + normalized germline VCF |
+```bash
+conda create -n snakemake -c conda-forge -c bioconda 'snakemake>=8.0'
+conda activate snakemake
+pip install snakemake-executor-plugin-slurm
+```
 
-Set `caller` in `config/config.yaml` to `"mutect2"`, `"freebayes"`, or `"all"`.
+### 3. Set up reference data
 
-## Configuration
+Follow the [lab handbook: Reference Data Setup](https://github.com/scholl-lab/lab-handbook/blob/main/docs/reference-data-setup.md).
+
+**BIH HPC** — shared data already exists:
+
+```
+/data/cephfs-1/work/groups/scholl/shared/ref/GRCh38/
+/data/cephfs-1/work/projects/apa-sequencing/analysis/GATK_resource_bundle/
+```
+
+**Charite HPC** — set up per project:
+
+```
+/sc-projects/<your-project>/resources/ref/GRCh38/
+/sc-projects/<your-project>/resources/gatk_bundle/
+```
+
+### Recommended project layout
+
+```
+/sc-projects/<your-project>/
+├── sm-alignment/                    # alignment pipeline (upstream)
+├── sm-calling/                      # this pipeline (git clone)
+│   ├── workflow/
+│   ├── config/
+│   │   ├── config.yaml              # ← edit or generate for your project
+│   │   └── samples.tsv              # ← generate from BAM filenames
+│   ├── profiles/
+│   └── scripts/
+├── resources/                       # reference data (or symlinks to shared)
+│   ├── ref/GRCh38/
+│   └── gatk_bundle/
+└── results/
+    └── exomes/
+        ├── bqsr/                    # BAMs from sm-alignment (input)
+        └── variant_calls/           # outputs from sm-calling
+```
+
+---
+
+## Generate Config Files
+
+The config generator scans your BAM directory, classifies tumor/normal roles by filename, pairs tumors with normals, and writes `config/samples.tsv` and `config/config.yaml`.
+
+### Interactive wizard (recommended for first-time setup)
+
+Run without arguments for a guided 3-step workflow:
+
+```bash
+python scripts/generate_config.py
+```
+
+```
+============================================================
+  sm-calling -- Config Generator
+============================================================
+
+BAM folder [results/exomes/bqsr]: /data/bams
+BAM extension [.merged.dedup.bqsr.bam]:
+
+Found 4 BAMs:
+
+  #  Basename                         Size      Role     Reason
+  1  A5297_DNA_01_STREAM_P1_L1       45.3 GB   ?        (no pattern matched)
+  2  A5297_DNA_02_STREAM_P1_N1       19.2 GB   normal   suffix '_N1'
+  3  APA1-T                           8.1 GB   tumor    suffix '-T'
+  4  APA1-N                           4.2 GB   normal   suffix '-N'
+```
+
+The wizard has three phases:
+
+1. **Propose** — scan BAMs, auto-detect roles (tumor/normal) from filename suffixes (`-T`, `_N1`, `_tumor`, etc.), prompt only for unrecognized BAMs
+2. **Review** — show the complete proposed table, accept or edit individual rows, switch analysis mode
+3. **Write** — confirm output paths, optionally scan for reference genome and GATK resources, write files
+
+Happy path = **3 interactions**: BAM folder → Accept table → Write confirm.
+
+### From sm-alignment output (flags mode)
+
+When you have analysis-ready BAMs from [sm-alignment](https://github.com/scholl-lab/sm-alignment):
+
+```bash
+# Generate samples.tsv from BAM directory
+python scripts/generate_config.py \
+    --bam-folder results/exomes/bqsr/
+
+# Output:
+#   Found 4 BAMs
+#   Proposed samples.tsv: 2 tumor_only, 2 tumor_normal (4 rows)
+#   Written: config/samples.tsv (4 rows)
+```
+
+### Options
+
+```bash
+# Preview without writing (dry-run)
+python scripts/generate_config.py --bam-folder /path/to/bams --dry-run
+
+# Generate samples.tsv AND config.yaml
+python scripts/generate_config.py --bam-folder /path/to/bams --config-template
+
+# Specify caller and scatter mode
+python scripts/generate_config.py --bam-folder /path/to/bams --config-template \
+    --caller mutect2 --scatter-mode chromosome
+
+# Tumor-only analysis only (no tumor-normal pairs)
+python scripts/generate_config.py --bam-folder /path/to/bams --analysis-mode tumor_only
+
+# Germline-only analysis
+python scripts/generate_config.py --bam-folder /path/to/bams --analysis-mode germline
+
+# Point to specific reference and GATK resource directories
+python scripts/generate_config.py --bam-folder /path/to/bams --config-template \
+    --ref-dir /resources/ref/GRCh38 --gatk-resource-dir /resources/gatk_bundle
+
+# Overwrite existing files
+python scripts/generate_config.py --bam-folder /path/to/bams --force
+```
+
+**Full CLI reference:**
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--bam-folder PATH` | *(interactive)* | BAM directory (triggers non-interactive mode) |
+| `--bam-extension EXT` | `.merged.dedup.bqsr.bam` | BAM file extension |
+| `--analysis-mode MODE` | `both` | `auto`, `tumor_only`, `tumor_normal`, `both`, `germline` |
+| `--caller CALLER` | `mutect2` | `mutect2`, `freebayes`, `all` |
+| `--output PATH` | `config/samples.tsv` | Output samples.tsv path |
+| `--config-template` | off | Also generate config.yaml |
+| `--config-output PATH` | `config/config.yaml` | Config.yaml output path |
+| `--ref-dir PATH` | *(auto-scan)* | Reference genome directory |
+| `--gatk-resource-dir PATH` | *(auto-scan)* | GATK resource VCF directory |
+| `--scatter-mode MODE` | `chromosome` | `chromosome`, `interval`, `none` |
+| `--dry-run` | off | Preview without writing |
+| `--force` | off | Overwrite without asking |
+
+When `--config-template` is used, the script scans for reference data:
+
+1. **Explicit** `--ref-dir` and `--gatk-resource-dir` (if provided)
+2. **Relative** paths near the project (`resources/ref/GRCh38/`, `analysis/GATK_resource_bundle/`, etc.)
+3. **Shared BIH HPC** locations (`/data/cephfs-1/work/groups/scholl/shared/ref/GRCh38/`)
+
+Discovered paths are written into `config/config.yaml`. Paths not found are marked with `EDIT_ME:` placeholders.
+
+### Role detection
+
+The script recognizes tumor and normal BAMs by filename suffix:
+
+| Pattern | Detected role | Examples |
+|---------|--------------|----------|
+| `-T`, `-T1`, `_TS` | tumor | `APA1-T`, `SAMPLE-T1` |
+| `_tumor`, `.FFPE`, `-met`, `_primary` | tumor | `S1_tumor`, `S1.FFPE` |
+| `-N`, `-N1` | normal | `APA1-N`, `A5297_P1_N1` |
+| `_normal`, `-blood`, `_germline`, `.pbmc` | normal | `S1_normal`, `S1-blood` |
+| *(no match)* | unknown (prompted) | `A5297_DNA_01_STREAM_P1_L1` |
+
+Pairing uses patient ID extraction (strip role suffix) first, then falls back to string similarity for complex names.
+
+---
+
+## Configuration Reference
 
 ### `config/config.yaml`
 
-Unified hierarchical configuration. Key sections:
+Review and adjust after generating:
 
-| Section | Description |
+```yaml
+caller: "mutect2"                    # "mutect2" | "freebayes" | "all"
+
+ref:
+  genome: "/path/to/GRCh38.fna"     # reference FASTA (must have .fai)
+  build: "GRCh38"                    # "GRCh37" or "GRCh38"
+
+gatk_resources:                      # required for Mutect2
+  panel_of_normals: "/path/to/1000g_pon.hg38.vcf.gz"
+  af_only_gnomad: "/path/to/af-only-gnomad.hg38.vcf.gz"
+  common_biallelic_gnomad: "/path/to/af-only-gnomad.hg38.common_biallelic.vcf.gz"
+
+paths:
+  samples: "config/samples.tsv"      # path to sample sheet
+  bam_folder: "results/exomes/bqsr"  # input BAMs
+  output_folder: "results/exomes/variant_calls"
+
+bam:
+  file_extension: ".merged.dedup.bqsr.bam"
+
+scatter:
+  mode: "chromosome"                 # "chromosome" | "interval" | "none"
+  count: 400                         # intervals (for interval mode)
+  chromosomes: ["chr1", ..., "chrY", "chrM"]
+
+params:                              # extra CLI args passed through to tools
+  mutect2:
+    extra: "--genotype-germline-sites true --genotype-pon-sites true"
+  freebayes:
+    extra: "--min-coverage 20 --limit-coverage 500"
+  bcftools_norm:
+    extra: "-m-any --force -a --atom-overlaps ."
+```
+
+| Section | Key settings |
 |---------|-------------|
 | `caller` | Which caller(s) to run |
 | `ref` | Reference genome path and build |
-| `gatk_resources` | Panel of normals, gnomAD files (Mutect2) |
-| `paths` | Input BAM folder, output folder, samples TSV |
-| `bam` | BAM file extension |
-| `scatter` | Scatter mode (`chromosome` / `interval` / `none`) |
-| `params` | Tool-specific extra arguments |
+| `gatk_resources` | Panel of normals, gnomAD files (required for Mutect2) |
+| `paths` | Input BAM folder, output folder, samples TSV path |
+| `bam` | BAM file extension (must match sm-alignment output) |
+| `scatter` | Parallelization mode and chromosome list |
+| `params` | Tool-specific extra arguments (passthrough strings) |
 
 ### `config/samples.tsv`
 
-Tab-separated sample sheet:
+One row per analysis. Generated by `scripts/generate_config.py` or written manually:
 
 ```
 sample          tumor_bam          normal_bam        analysis_type
@@ -56,30 +258,105 @@ IND002_TN       IND002.tumor       IND002.normal     tumor_normal
 IND003_G        IND003             .                 germline
 ```
 
-- `sample`: Unique identifier (used in output filenames)
-- `tumor_bam`: BAM basename (without extension)
-- `normal_bam`: Matched normal basename, or `.` if none
-- `analysis_type`: One of `tumor_only`, `tumor_normal`, `germline`
+| Column | Description |
+|--------|-------------|
+| `sample` | Unique identifier (used in output filenames) |
+| `tumor_bam` | BAM basename without extension (not the full path) |
+| `normal_bam` | Matched normal BAM basename, or `.` if none |
+| `analysis_type` | `tumor_only`, `tumor_normal`, or `germline` |
 
-## Running on HPC
+A single patient can have **multiple rows** (e.g., both `tumor_only` and `tumor_normal`). The config generator's default `both` mode creates this automatically.
 
-The launcher auto-detects the cluster environment:
+### Profiles
+
+Resource and executor settings are separated into layered profiles:
+
+| Profile | Purpose | Applied via |
+|---------|---------|-------------|
+| `profiles/default/` | Per-rule threads, memory, walltime | `--workflow-profile` |
+| `profiles/bih/` | BIH SLURM settings (partition, account) | `--profile` |
+| `profiles/charite/` | Charite SLURM settings (partition overrides) | `--profile` |
+| `profiles/local/` | Local execution (4 cores, conda) | `--profile` |
+
+To adjust resources without touching workflow code, edit `profiles/default/config.v8+.yaml`.
+
+---
+
+## Supported Callers
+
+| Caller | Analysis types | Output |
+|--------|---------------|--------|
+| **Mutect2** | `tumor_only`, `tumor_normal` | Filtered somatic VCF per sample |
+| **FreeBayes** | `germline` | Merged + normalized germline VCF |
+
+Set `caller: "all"` in config to run both.
+
+---
+
+## Run the Pipeline
+
+### Dry-run first
+
+Always verify the execution plan before submitting:
 
 ```bash
-# Submit via SLURM (auto-detects BIH or Charite):
-sbatch scripts/run_snakemake.sh
+conda activate snakemake
 
-# Custom config:
-sbatch scripts/run_snakemake.sh config/my_config.yaml
-
-# Dry-run (local):
-bash scripts/run_snakemake.sh config/config.yaml -n
-
-# Pass extra Snakemake flags:
-sbatch scripts/run_snakemake.sh config/config.yaml --forcerun mutect2_call
+snakemake -s workflow/Snakefile --configfile config/config.yaml -n
 ```
 
-Or invoke Snakemake directly:
+### Submit to SLURM
+
+```bash
+# Create log directory
+mkdir -p slurm_logs
+
+# Submit — cluster is auto-detected
+sbatch scripts/run_snakemake.sh
+```
+
+The launcher auto-detects whether you're on BIH HPC or Charite HPC:
+
+| Cluster | Detection | Behavior |
+|---------|-----------|----------|
+| **BIH HPC** | `cubi-v1` profile exists | `--profile profiles/bih` |
+| **Charite HPC** | `/etc/profile.d/conda.sh` exists | `--profile profiles/charite`, partition overrides for long jobs |
+| **Other/local** | Fallback | `--profile profiles/local` |
+
+### Usage examples
+
+```bash
+# Custom config file
+sbatch scripts/run_snakemake.sh config/my_config.yaml
+
+# Custom job name (visible in squeue)
+sbatch --job-name=sm_exomes scripts/run_snakemake.sh
+
+# Pass extra Snakemake flags
+sbatch scripts/run_snakemake.sh config/config.yaml --forceall
+
+# Override resources for a single run
+sbatch scripts/run_snakemake.sh config/config.yaml \
+    --set-threads mutect2_call=8 --set-resources mutect2_call:mem_mb=24000
+
+# Run locally without cluster submission
+bash scripts/run_snakemake.sh config/config.yaml
+```
+
+### Monitor progress
+
+```bash
+# Check running jobs
+squeue -u $USER
+
+# Follow coordinator log
+tail -f slurm_logs/sm_calling-*.log
+
+# Follow individual rule logs
+tail -f slurm_logs/slurm-*.log
+```
+
+### Invoke Snakemake directly
 
 ```bash
 snakemake \
@@ -89,45 +366,76 @@ snakemake \
     --profile profiles/bih
 ```
 
+---
+
 ## Pipeline Architecture
 
 ```
 workflow/Snakefile
-    |
-    +-- rules/common.smk      Config shortcuts, metadata, helpers
-    +-- rules/scatter.smk      Interval scattering (shared)
-    +-- rules/mutect2.smk      Mutect2: call -> gather -> contamination -> filter
-    +-- rules/freebayes.smk    FreeBayes: call -> merge + normalize
+    │
+    ├── rules/common.smk      Config shortcuts, samples_df, input helpers
+    ├── rules/helpers.py       Pure Python functions (unit-testable)
+    ├── rules/scatter.smk      Interval scattering (shared by both callers)
+    ├── rules/mutect2.smk      Mutect2: call → gather → contamination → filter
+    └── rules/freebayes.smk    FreeBayes: call → merge + normalize
 ```
 
 ### Mutect2 DAG
 
 ```
 BAM files
-    +-> mutect2_call (per sample x scatter_unit)        [temp]
-    +-> get_pileup_summaries (per unique BAM)
-    +-> gather_mutect2_vcfs (per sample)
-    +-> merge_mutect2_stats (per sample)
-    +-> learn_read_orientation (per sample)
-    +-> calculate_contamination (per sample)
-    +-> filter_mutect_calls (per sample)                [protected]
+    ├── mutect2_call (per sample x scatter_unit)        [temp]
+    ├── get_pileup_summaries (per unique BAM)
+    ├── gather_mutect2_vcfs (per sample)
+    ├── merge_mutect2_stats (per sample)
+    ├── learn_read_orientation (per sample)
+    ├── calculate_contamination (per sample)
+    └── filter_mutect_calls (per sample)                [protected]
 ```
 
 ### FreeBayes DAG
 
 ```
 BAM files
-    +-> freebayes_call (per scatter_unit)               [temp]
-    +-> merge_freebayes_vcfs                            [protected]
+    ├── freebayes_call (per scatter_unit)               [temp]
+    └── merge_freebayes_vcfs                            [protected]
 ```
+
+---
+
+## Tools & Conda Environments
+
+| Conda env | Tools | Used by |
+|-----------|-------|---------|
+| `workflow/envs/gatk.yaml` | gatk4 4.6.1.0, samtools 1.21 | Mutect2 pipeline |
+| `workflow/envs/freebayes.yaml` | freebayes 1.3.8, htslib 1.21 | FreeBayes calling |
+| `workflow/envs/bcftools.yaml` | bcftools 1.21, htslib 1.21 | VCF merge + normalize |
+
+Conda environments are created automatically by Snakemake on first run (`software-deployment-method: conda` in the workflow profile).
+
+To skip per-rule conda and use pre-installed tools instead:
+
+```bash
+# Install tools into the snakemake environment
+mamba install -n snakemake -c bioconda -c conda-forge \
+    gatk4=4.6.1.0 samtools=1.21 freebayes=1.3.8 bcftools=1.21 htslib=1.21
+
+# Run with --sdm none
+sbatch scripts/run_snakemake.sh config/config.yaml --sdm none
+```
+
+---
 
 ## Development
 
 ```bash
-# Lint
+# Install dev tools
+pip install ruff mypy snakefmt shellcheck-py pytest
+
+# Run all checks
 make lint
 
-# Format
+# Auto-format
 make format
 
 # Run unit tests
@@ -135,22 +443,36 @@ make test-unit
 
 # Run all tests (requires snakemake + conda)
 make test
+
+# Type check
+make typecheck
 ```
+
+---
 
 ## Project Structure
 
 ```
 sm-calling/
-+-- config/              Configuration and sample sheet
-+-- workflow/
-|   +-- Snakefile        Entry point (Snakemake 8+)
-|   +-- rules/           Rule files + helpers.py
-|   +-- envs/            Conda environment definitions
-|   +-- schemas/          JSON schemas for validation
-+-- profiles/            Snakemake profiles (default, bih, charite, local)
-+-- scripts/             Universal launcher
-+-- tests/               pytest unit and integration tests
-+-- deprecated/          Old standalone workflows (preserved for reference)
+├── config/
+│   ├── config.yaml              Main configuration
+│   ├── samples.tsv              Sample sheet
+│   └── README.md                Config field reference
+├── workflow/
+│   ├── Snakefile                Entry point (Snakemake 8+)
+│   ├── rules/                   Rule files + helpers.py
+│   ├── envs/                    Conda environment YAMLs
+│   └── schemas/                 JSON schemas for validation
+├── profiles/
+│   ├── default/                 Per-rule resources (threads, memory, walltime)
+│   ├── bih/                     BIH SLURM executor settings
+│   ├── charite/                 Charite SLURM executor settings
+│   └── local/                   Local execution (no cluster)
+├── scripts/
+│   ├── generate_config.py       Config generator (interactive + CLI)
+│   └── run_snakemake.sh         SLURM launcher (auto-detects cluster)
+├── tests/                       pytest unit and integration tests
+└── deprecated/                  Old standalone workflows (for reference)
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -97,13 +97,12 @@ python scripts/generate_config.py
 BAM folder [results/exomes/bqsr]: /data/bams
 BAM extension [.merged.dedup.bqsr.bam]:
 
-Found 4 BAMs:
+Found 3 BAMs:
 
-  #  Basename                         Size      Role     Reason
-  1  A5297_DNA_01_STREAM_P1_L1       45.3 GB   ?        (no pattern matched)
-  2  A5297_DNA_02_STREAM_P1_N1       19.2 GB   normal   suffix '_N1'
-  3  APA1-T                           8.1 GB   tumor    suffix '-T'
-  4  APA1-N                           4.2 GB   normal   suffix '-N'
+  #  Basename              Size      Role     Reason
+  1  SAMPLE01-T           45.3 GB   tumor    suffix '-T'
+  2  SAMPLE01-N           19.2 GB   normal   suffix '-N'
+  3  SAMPLE02_tumor        8.1 GB   tumor    suffix '_tumor'
 ```
 
 The wizard has three phases:
@@ -187,11 +186,11 @@ The script recognizes tumor and normal BAMs by filename suffix:
 
 | Pattern | Detected role | Examples |
 |---------|--------------|----------|
-| `-T`, `-T1`, `_TS` | tumor | `APA1-T`, `SAMPLE-T1` |
+| `-T`, `-T1`, `_TS` | tumor | `SAMPLE01-T`, `SAMPLE-T1` |
 | `_tumor`, `.FFPE`, `-met`, `_primary` | tumor | `S1_tumor`, `S1.FFPE` |
-| `-N`, `-N1` | normal | `APA1-N`, `A5297_P1_N1` |
+| `-N`, `-N1` | normal | `SAMPLE01-N`, `SAMPLE_P1_N1` |
 | `_normal`, `-blood`, `_germline`, `.pbmc` | normal | `S1_normal`, `S1-blood` |
-| *(no match)* | unknown (prompted) | `A5297_DNA_01_STREAM_P1_L1` |
+| *(no match)* | unknown (prompted) | `SAMPLE_DNA_01_STREAM_P1_L1` |
 
 Pairing uses patient ID extraction (strip role suffix) first, then falls back to string similarity for complex names.
 

--- a/scripts/generate_config.py
+++ b/scripts/generate_config.py
@@ -1,0 +1,1413 @@
+#!/usr/bin/env python3
+"""Generate config/samples.tsv and config/config.yaml for the sm-calling pipeline.
+
+Scans a BAM directory, classifies tumor/normal roles via filename heuristics,
+pairs tumors with normals, and generates the pipeline config files.
+
+Two modes:
+  Interactive:  python scripts/generate_config.py          (guided wizard)
+  Flags:        python scripts/generate_config.py --bam-folder /path/to/bams
+
+Usage:
+    python scripts/generate_config.py
+    python scripts/generate_config.py --bam-folder /data/bams
+    python scripts/generate_config.py --bam-folder /data/bams --dry-run
+    python scripts/generate_config.py --bam-folder /data/bams --config-template --caller mutect2
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from difflib import SequenceMatcher
+from pathlib import Path
+from typing import Any
+
+try:
+    import pandas as pd
+except ImportError:
+    sys.exit(
+        "Error: pandas is required but not installed.\n"
+        "Install it with: pip install pandas\n"
+        "(pandas is already available in Snakemake conda environments.)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Section A: Constants & Patterns
+# ---------------------------------------------------------------------------
+
+DEFAULT_BAM_EXTENSION = ".merged.dedup.bqsr.bam"
+
+# Patterns that identify tumor BAMs (applied to the basename without extension)
+TUMOR_PATTERNS = [
+    (
+        re.compile(r"[._-](?:tumor|tumour|FFPE|met|metastatic|primary|tum)$", re.I),
+        "suffix '{match}'",
+    ),
+    (
+        re.compile(r"[._-]T[A-Z]?\d*$"),
+        "suffix '{match}'",
+    ),
+]
+
+# Patterns that identify normal BAMs
+NORMAL_PATTERNS = [
+    (
+        re.compile(r"[._-](?:normal|blood|buffy|germline|pbmc|ctrl)$", re.I),
+        "suffix '{match}'",
+    ),
+    (
+        re.compile(r"[._-]N\d*$"),
+        "suffix '{match}'",
+    ),
+]
+
+# Combined pattern for stripping role suffixes to extract patient ID
+ROLE_SUFFIX_RE = re.compile(
+    r"[._-](?:tumor|tumour|FFPE|met|metastatic|primary|tum|"
+    r"normal|blood|buffy|germline|pbmc|ctrl|"
+    r"T[A-Z]?\d*|N\d*)$",
+    re.I,
+)
+
+# Reference genome file extensions
+GENOME_EXTENSIONS = ("*.fna", "*.fa", "*.fasta")
+
+# GATK resource search patterns
+GATK_RESOURCE_PATTERNS = {
+    "panel_of_normals": ["*pon*.vcf*", "*1000g_pon*.vcf*"],
+    "af_only_gnomad": ["*af-only-gnomad*.vcf*"],
+    "common_biallelic_gnomad": ["*common_biallelic*.vcf*"],
+}
+
+# Standard search directories for reference data (relative to project root)
+REF_SEARCH_DIRS = [
+    "resources/ref",
+    "resources/ref/GRCh38",
+    "analysis/ref/GRCh38",
+    "../resources/ref/GRCh38",
+    "../resources/ref",
+]
+
+# GATK resource bundle search directories
+GATK_RESOURCE_SEARCH_DIRS = [
+    "resources/gatk_bundle/hg38",
+    "resources/gatk_bundle",
+    "analysis/GATK_resource_bundle",
+    "../resources/gatk_bundle/hg38",
+    "../resources/gatk_bundle",
+]
+
+# Well-known shared locations on BIH and Charite HPC
+SHARED_REF_DIRS = [
+    "/data/cephfs-1/work/groups/scholl/shared/ref/GRCh38",
+    "/data/cephfs-1/work/groups/scholl/shared/ref",
+]
+
+SHARED_GATK_DIRS = [
+    "/data/cephfs-1/work/projects/apa-sequencing/analysis/GATK_resource_bundle",
+]
+
+# Default chromosomes for scatter mode
+DEFAULT_CHROMOSOMES = [f"chr{i}" for i in range(1, 23)] + ["chrX", "chrY", "chrM"]
+
+
+# ---------------------------------------------------------------------------
+# Section B: BAM Discovery
+# ---------------------------------------------------------------------------
+
+
+def discover_bam_files(bam_folder: str | Path, bam_extension: str) -> list[dict]:
+    """Scan a directory for BAM files matching the given extension.
+
+    Args:
+        bam_folder: Directory to scan.
+        bam_extension: File extension to match (e.g., '.merged.dedup.bqsr.bam').
+
+    Returns:
+        List of dicts with keys: basename, path, size_bytes, has_index.
+        Sorted alphabetically by basename.
+    """
+    bam_dir = Path(bam_folder)
+    if not bam_dir.is_dir():
+        return []
+
+    results = []
+    all_files = sorted(bam_dir.iterdir())
+    bam_files = [f for f in all_files if f.is_file() and f.name.endswith(bam_extension)]
+
+    for bam_path in bam_files:
+        basename = bam_path.name[: -len(bam_extension)]
+        # Check for .bai index (both conventions: file.bam.bai and file.bai)
+        has_index = (
+            (bam_dir / (bam_path.name + ".bai")).is_file()
+            or (bam_dir / (basename + bam_extension[:-4] + ".bai")).is_file()
+            or (bam_dir / (bam_path.name[:-4] + ".bai")).is_file()
+        )
+        results.append(
+            {
+                "basename": basename,
+                "path": str(bam_path),
+                "size_bytes": bam_path.stat().st_size,
+                "has_index": has_index,
+            }
+        )
+
+    return results
+
+
+def format_size(size_bytes: int) -> str:
+    """Format file size in human-readable form.
+
+    Args:
+        size_bytes: File size in bytes.
+
+    Returns:
+        Formatted string like '45.3 GB', '512 MB', '1.2 KB'.
+    """
+    if size_bytes >= 1_000_000_000:
+        return f"{size_bytes / 1_000_000_000:.1f} GB"
+    if size_bytes >= 1_000_000:
+        return f"{size_bytes / 1_000_000:.1f} MB"
+    if size_bytes >= 1_000:
+        return f"{size_bytes / 1_000:.1f} KB"
+    return f"{size_bytes} B"
+
+
+# ---------------------------------------------------------------------------
+# Section C: Role Detection + Patient Grouping
+# ---------------------------------------------------------------------------
+
+
+def guess_role(basename: str) -> tuple[str, str]:
+    """Guess whether a BAM basename is tumor, normal, or unknown.
+
+    Args:
+        basename: BAM file basename (without extension).
+
+    Returns:
+        Tuple of (role, reason) where role is 'tumor', 'normal', or 'unknown'.
+    """
+    for pattern, reason_tpl in TUMOR_PATTERNS:
+        m = pattern.search(basename)
+        if m:
+            return ("tumor", reason_tpl.format(match=m.group()))
+
+    for pattern, reason_tpl in NORMAL_PATTERNS:
+        m = pattern.search(basename)
+        if m:
+            return ("normal", reason_tpl.format(match=m.group()))
+
+    return ("unknown", "no pattern matched")
+
+
+def extract_patient_id(basename: str) -> str:
+    """Extract patient ID by stripping the role suffix from a BAM basename.
+
+    Args:
+        basename: BAM file basename (without extension).
+
+    Returns:
+        Patient ID string. If no role suffix found, returns the basename as-is.
+    """
+    return ROLE_SUFFIX_RE.sub("", basename)
+
+
+def find_best_normal(
+    tumor_basename: str,
+    available_normals: list[str],
+    patient_groups: dict[str, dict[str, list[str]]] | None = None,
+) -> str | None:
+    """Find the best matching normal BAM for a tumor BAM.
+
+    Priority:
+        1. Same patient_id (from patient_groups)
+        2. Highest string similarity (SequenceMatcher)
+
+    Args:
+        tumor_basename: Basename of the tumor BAM.
+        available_normals: List of normal BAM basenames.
+        patient_groups: Optional patient grouping dict.
+
+    Returns:
+        Best matching normal basename, or None if no match above threshold.
+    """
+    if not available_normals:
+        return None
+
+    # Priority 1: same patient ID
+    if patient_groups is not None:
+        tumor_pid = extract_patient_id(tumor_basename)
+        for normal in available_normals:
+            normal_pid = extract_patient_id(normal)
+            if tumor_pid == normal_pid:
+                return normal
+
+    # Priority 2: string similarity
+    best, best_score = None, 0.0
+    for normal in available_normals:
+        score = SequenceMatcher(None, tumor_basename, normal).ratio()
+        if score > best_score:
+            best, best_score = normal, score
+
+    return best if best_score > 0.5 else None
+
+
+def group_and_pair(bam_entries: list[dict]) -> tuple[dict[str, dict[str, list[str]]], list[dict]]:
+    """Group BAMs by patient ID and pair tumors with normals.
+
+    Args:
+        bam_entries: List of dicts with at least 'basename' and 'role' keys.
+
+    Returns:
+        Tuple of (patient_groups, pairings).
+        patient_groups: {patient_id: {tumors: [...], normals: [...]}}.
+        pairings: [{tumor: basename, normal: basename|None, patient_id: str}, ...].
+    """
+    # Group by patient ID
+    patient_groups: dict[str, dict[str, list[str]]] = {}
+    for entry in bam_entries:
+        if entry.get("role") == "skip":
+            continue
+        pid = extract_patient_id(entry["basename"])
+        if pid not in patient_groups:
+            patient_groups[pid] = {"tumors": [], "normals": []}
+        role = entry.get("role", "unknown")
+        if role == "tumor":
+            patient_groups[pid]["tumors"].append(entry["basename"])
+        elif role == "normal":
+            patient_groups[pid]["normals"].append(entry["basename"])
+
+    # Pair tumors with normals
+    pairings: list[dict] = []
+    used_normals: set[str] = set()
+
+    # All normals (for cross-patient fallback)
+    all_normals = [
+        e["basename"] for e in bam_entries if e.get("role") == "normal"
+    ]
+
+    for pid, group in patient_groups.items():
+        for tumor in group["tumors"]:
+            # Try same-patient normals first
+            normal = None
+            for n in group["normals"]:
+                if n not in used_normals:
+                    normal = n
+                    break
+
+            # If no same-patient normal, try cross-patient via similarity
+            if normal is None:
+                remaining = [n for n in all_normals if n not in used_normals]
+                normal = find_best_normal(tumor, remaining, patient_groups)
+
+            if normal is not None:
+                used_normals.add(normal)
+
+            pairings.append(
+                {
+                    "tumor": tumor,
+                    "normal": normal,
+                    "patient_id": pid,
+                }
+            )
+
+    return patient_groups, pairings
+
+
+def generate_sample_name(patient_id: str, analysis_type: str, index: int, total: int) -> str:
+    """Generate a sample name from patient ID and analysis type.
+
+    Args:
+        patient_id: Patient identifier.
+        analysis_type: One of 'tumor_only', 'tumor_normal', 'germline'.
+        index: 0-based index for disambiguation.
+        total: Total samples of this type for this patient.
+
+    Returns:
+        Sample name like 'APA1_TN', 'APA1_To', 'APA1_G', or 'APA1_TN_2'.
+    """
+    suffix_map = {
+        "tumor_only": "To",
+        "tumor_normal": "TN",
+        "germline": "G",
+    }
+    suffix = suffix_map.get(analysis_type, analysis_type)
+    name = f"{patient_id}_{suffix}"
+    if total > 1:
+        name = f"{name}_{index + 1}"
+    return name
+
+
+def generate_rows(
+    pairings: list[dict],
+    bam_entries: list[dict],
+    analysis_mode: str,
+) -> list[dict]:
+    """Generate sample rows for the given analysis mode.
+
+    Args:
+        pairings: From group_and_pair().
+        bam_entries: Original BAM entries (for germline mode).
+        analysis_mode: One of 'both', 'tumor_only', 'tumor_normal', 'germline'.
+
+    Returns:
+        List of dicts with keys: sample, tumor_bam, normal_bam, analysis_type, patient_id.
+    """
+    rows: list[dict] = []
+
+    if analysis_mode == "germline":
+        # One row per BAM (use tumor_bam column for the BAM, regardless of role)
+        patient_counts: dict[str, int] = {}
+        for entry in bam_entries:
+            if entry.get("role") == "skip":
+                continue
+            pid = extract_patient_id(entry["basename"])
+            patient_counts[pid] = patient_counts.get(pid, 0) + 1
+
+        patient_indices: dict[str, int] = {}
+        for entry in bam_entries:
+            if entry.get("role") == "skip":
+                continue
+            pid = extract_patient_id(entry["basename"])
+            idx = patient_indices.get(pid, 0)
+            patient_indices[pid] = idx + 1
+            sample = generate_sample_name(pid, "germline", idx, patient_counts[pid])
+            rows.append(
+                {
+                    "sample": sample,
+                    "tumor_bam": entry["basename"],
+                    "normal_bam": ".",
+                    "analysis_type": "germline",
+                    "patient_id": pid,
+                }
+            )
+        return rows
+
+    # Count per-patient for disambiguation
+    patient_type_counts: dict[str, dict[str, int]] = {}
+    for pairing in pairings:
+        pid = pairing["patient_id"]
+        if pid not in patient_type_counts:
+            patient_type_counts[pid] = {"tumor_only": 0, "tumor_normal": 0}
+        if analysis_mode in ("both", "tumor_only"):
+            patient_type_counts[pid]["tumor_only"] += 1
+        if analysis_mode in ("both", "tumor_normal") and pairing["normal"] is not None:
+            patient_type_counts[pid]["tumor_normal"] += 1
+
+    patient_type_indices: dict[str, dict[str, int]] = {}
+
+    for pairing in pairings:
+        pid = pairing["patient_id"]
+        if pid not in patient_type_indices:
+            patient_type_indices[pid] = {"tumor_only": 0, "tumor_normal": 0}
+
+        # Tumor-only row
+        if analysis_mode in ("both", "tumor_only"):
+            idx = patient_type_indices[pid]["tumor_only"]
+            total = patient_type_counts[pid]["tumor_only"]
+            patient_type_indices[pid]["tumor_only"] = idx + 1
+            sample = generate_sample_name(pid, "tumor_only", idx, total)
+            rows.append(
+                {
+                    "sample": sample,
+                    "tumor_bam": pairing["tumor"],
+                    "normal_bam": ".",
+                    "analysis_type": "tumor_only",
+                    "patient_id": pid,
+                }
+            )
+
+        # Tumor-normal row
+        if analysis_mode in ("both", "tumor_normal") and pairing["normal"] is not None:
+            idx = patient_type_indices[pid]["tumor_normal"]
+            total = patient_type_counts[pid]["tumor_normal"]
+            patient_type_indices[pid]["tumor_normal"] = idx + 1
+            sample = generate_sample_name(pid, "tumor_normal", idx, total)
+            rows.append(
+                {
+                    "sample": sample,
+                    "tumor_bam": pairing["tumor"],
+                    "normal_bam": pairing["normal"],
+                    "analysis_type": "tumor_normal",
+                    "patient_id": pid,
+                }
+            )
+
+    return rows
+
+
+# ---------------------------------------------------------------------------
+# Section D: Reference + GATK Resource Discovery
+# ---------------------------------------------------------------------------
+
+
+def _find_genome_fastas(search_dir: Path) -> list[dict[str, Any]]:
+    """Find reference genome FASTA files in a directory.
+
+    Args:
+        search_dir: Directory to search.
+
+    Returns:
+        List of dicts with keys: path, has_fai, name.
+    """
+    results: list[dict[str, Any]] = []
+    if not search_dir.is_dir():
+        return results
+    for ext in GENOME_EXTENSIONS:
+        for fasta in search_dir.glob(ext):
+            if fasta.name.startswith("."):
+                continue
+            has_fai = (fasta.parent / (fasta.name + ".fai")).is_file()
+            results.append(
+                {
+                    "path": str(fasta),
+                    "has_fai": has_fai,
+                    "name": fasta.name,
+                }
+            )
+    return results
+
+
+def _find_gatk_resource_vcfs(
+    search_dir: Path,
+    resource_key: str,
+    patterns: list[str],
+) -> list[str]:
+    """Find GATK resource VCF files matching glob patterns.
+
+    Args:
+        search_dir: Directory to search.
+        resource_key: Resource identifier (for exclusion logic).
+        patterns: Glob patterns to match.
+
+    Returns:
+        List of file path strings (deduplicated).
+    """
+    results: list[str] = []
+    if not search_dir.is_dir():
+        return results
+    for pattern in patterns:
+        for vcf in search_dir.glob(pattern):
+            if vcf.name.endswith(".tbi") or vcf.name.endswith(".idx"):
+                continue
+            # For af_only_gnomad, exclude files with 'common' in the name
+            if resource_key == "af_only_gnomad" and "common" in vcf.name.lower():
+                continue
+            results.append(str(vcf))
+    return sorted(set(results))
+
+
+def discover_reference_data(
+    ref_dir: Path | None,
+    project_root: Path | None = None,
+) -> dict[str, Any]:
+    """Scan for reference genome FASTA files.
+
+    Args:
+        ref_dir: Explicit reference directory to search first.
+        project_root: Project root for relative path searches.
+
+    Returns:
+        Dict with keys: genome, build, search_log.
+    """
+    search_log: list[str] = []
+    genomes: list[dict[str, Any]] = []
+
+    ref_search: list[Path] = []
+    if ref_dir:
+        ref_search.append(ref_dir)
+    if project_root:
+        for rel in REF_SEARCH_DIRS:
+            ref_search.append(project_root / rel)
+    for shared in SHARED_REF_DIRS:
+        ref_search.append(Path(shared))
+
+    for search_path in ref_search:
+        if not search_path.is_dir():
+            continue
+        found = _find_genome_fastas(search_path)
+        if found:
+            search_log.append(f"  Found {len(found)} genome(s) in {search_path}")
+            for g in found:
+                status = "FAI" if g["has_fai"] else "no index"
+                search_log.append(f"    {g['name']}  [{status}]")
+            genomes.extend(found)
+
+    genome_path = ""
+    build = "GRCh38"
+    if genomes:
+        best = sorted(genomes, key=lambda g: (g["has_fai"], bool(g["path"])), reverse=True)[0]
+        genome_path = str(Path(best["path"]).resolve()) if best["path"] else ""
+        name_lower = best["name"].lower()
+        if "grch37" in name_lower or "hg19" in name_lower or "hs37" in name_lower:
+            build = "GRCh37"
+
+    if not genomes:
+        search_log.append("  No reference genome found")
+
+    return {
+        "genome": genome_path,
+        "build": build,
+        "search_log": search_log,
+    }
+
+
+def discover_gatk_resources(
+    resource_dir: Path | None,
+    project_root: Path | None = None,
+) -> dict[str, Any]:
+    """Scan for GATK resource VCFs (PoN, gnomAD).
+
+    Args:
+        resource_dir: Explicit resource directory to search first.
+        project_root: Project root for relative path searches.
+
+    Returns:
+        Dict with keys: panel_of_normals, af_only_gnomad,
+        common_biallelic_gnomad, search_log.
+    """
+    search_log: list[str] = []
+    found_resources: dict[str, str] = {
+        "panel_of_normals": "",
+        "af_only_gnomad": "",
+        "common_biallelic_gnomad": "",
+    }
+
+    search_dirs: list[Path] = []
+    if resource_dir:
+        search_dirs.append(resource_dir)
+    if project_root:
+        for rel in GATK_RESOURCE_SEARCH_DIRS:
+            search_dirs.append(project_root / rel)
+    for shared in SHARED_GATK_DIRS:
+        search_dirs.append(Path(shared))
+
+    for search_path in search_dirs:
+        if not search_path.is_dir():
+            continue
+        for key, patterns in GATK_RESOURCE_PATTERNS.items():
+            if found_resources[key]:
+                continue  # already found
+            matches = _find_gatk_resource_vcfs(search_path, key, patterns)
+            if matches:
+                found_resources[key] = matches[0]
+                search_log.append(f"  Found {key}: {Path(matches[0]).name}")
+
+    for key, path in found_resources.items():
+        if not path:
+            search_log.append(f"  {key}: not found")
+
+    return {**found_resources, "search_log": search_log}
+
+
+# ---------------------------------------------------------------------------
+# Section E: Config Template
+# ---------------------------------------------------------------------------
+
+
+def _resolve_path(p: str) -> str:
+    """Resolve a path string to canonical form, skipping placeholders."""
+    if not p or "EDIT_ME" in p:
+        return p
+    return str(Path(p).resolve()).replace("\\", "/")
+
+
+def _build_config_yaml(
+    caller: str,
+    ref_data: dict[str, Any],
+    gatk_resources: dict[str, Any],
+    bam_folder: str,
+    output_folder: str,
+    samples_path: str,
+    bam_extension: str,
+    scatter_mode: str,
+) -> str:
+    """Build config.yaml content matching config.schema.yaml.
+
+    Uses string formatting (not yaml.dump) to preserve comments.
+
+    Args:
+        caller: Variant caller choice.
+        ref_data: From discover_reference_data().
+        gatk_resources: From discover_gatk_resources().
+        bam_folder: BAM input directory.
+        output_folder: Pipeline output directory.
+        samples_path: Path to samples.tsv.
+        bam_extension: BAM file extension.
+        scatter_mode: Scatter mode (chromosome/interval/none).
+
+    Returns:
+        YAML config file content as a string.
+    """
+    genome = ref_data.get("genome", "") or "EDIT_ME: /path/to/reference.fna"
+    build = ref_data.get("build", "GRCh38")
+
+    pon = gatk_resources.get("panel_of_normals", "") or "EDIT_ME: /path/to/pon.vcf.gz"
+    af_gnomad = (
+        gatk_resources.get("af_only_gnomad", "") or "EDIT_ME: /path/to/af-only-gnomad.vcf.gz"
+    )
+    common_gnomad = (
+        gatk_resources.get("common_biallelic_gnomad", "")
+        or "EDIT_ME: /path/to/common_biallelic.vcf.gz"
+    )
+
+    genome = _resolve_path(genome)
+    pon = _resolve_path(pon)
+    af_gnomad = _resolve_path(af_gnomad)
+    common_gnomad = _resolve_path(common_gnomad)
+    bam_folder = _resolve_path(bam_folder)
+
+    # Build chromosomes list
+    chrom_lines = "\n".join(f'    - "{c}"' for c in DEFAULT_CHROMOSOMES)
+
+    return f"""\
+# sm-calling unified configuration
+# Generated by: scripts/generate_config.py
+# Review all paths below before running the pipeline.
+
+# --- Caller selection ---
+caller: "{caller}"  # "mutect2" | "freebayes" | "all"
+
+# --- Reference genome ---
+ref:
+  genome: "{genome}"
+  build: "{build}"
+
+# --- GATK resources (required for Mutect2) ---
+gatk_resources:
+  panel_of_normals: "{pon}"
+  af_only_gnomad: "{af_gnomad}"
+  common_biallelic_gnomad: "{common_gnomad}"
+
+# --- Paths ---
+paths:
+  samples: "{samples_path}"
+  bam_folder: "{bam_folder}"
+  output_folder: "{output_folder}"
+  log_subdir: "logs"
+  intervals_dir: "analysis/intervals"
+
+# --- BAM file settings ---
+bam:
+  file_extension: "{bam_extension}"
+
+# --- Scatter settings ---
+scatter:
+  mode: "{scatter_mode}"  # "chromosome" | "interval" | "none"
+  count: 400
+  chromosomes:
+{chrom_lines}
+
+# --- Tool-specific parameters (passthrough) ---
+params:
+  mutect2:
+    extra: "--genotype-germline-sites true --genotype-pon-sites true"
+  freebayes:
+    extra: "--min-coverage 20 --limit-coverage 500 --use-best-n-alleles 4 --standard-filters"
+  bcftools_norm:
+    extra: "-m-any --force -a --atom-overlaps ."
+"""
+
+
+def generate_config_template(
+    config_output: Path,
+    caller: str,
+    ref_data: dict[str, Any],
+    gatk_resources: dict[str, Any],
+    bam_folder: str,
+    output_folder: str,
+    samples_path: str,
+    bam_extension: str,
+    scatter_mode: str,
+    dry_run: bool = False,
+    force: bool = False,
+) -> None:
+    """Write config.yaml with overwrite protection.
+
+    Args:
+        config_output: Path for the output config file.
+        caller: Variant caller choice.
+        ref_data: From discover_reference_data().
+        gatk_resources: From discover_gatk_resources().
+        bam_folder: BAM input directory.
+        output_folder: Pipeline output directory.
+        samples_path: Path to samples.tsv.
+        bam_extension: BAM file extension.
+        scatter_mode: Scatter mode.
+        dry_run: If True, print but don't write.
+        force: If True, overwrite without asking.
+    """
+    content = _build_config_yaml(
+        caller=caller,
+        ref_data=ref_data,
+        gatk_resources=gatk_resources,
+        bam_folder=bam_folder,
+        output_folder=output_folder,
+        samples_path=samples_path,
+        bam_extension=bam_extension,
+        scatter_mode=scatter_mode,
+    )
+
+    if dry_run:
+        print(f"\n--- Config template ({config_output}) ---")
+        print(content)
+        return
+
+    if config_output.is_file() and not force:
+        response = input(f"Config file already exists: {config_output}. Overwrite? [y/N] ")
+        if response.lower() not in ("y", "yes"):
+            print(f"Skipped writing {config_output}")
+            return
+
+    config_output.parent.mkdir(parents=True, exist_ok=True)
+    with open(config_output, "w", encoding="utf-8") as fh:
+        fh.write(content)
+    print(f"Written: {config_output}")
+
+
+# ---------------------------------------------------------------------------
+# Section F: Output
+# ---------------------------------------------------------------------------
+
+
+def build_samples_dataframe(rows: list[dict]) -> pd.DataFrame:
+    """Build a samples DataFrame from generated rows.
+
+    Args:
+        rows: List of row dicts with sample, tumor_bam, normal_bam, analysis_type keys.
+
+    Returns:
+        DataFrame with columns: sample, tumor_bam, normal_bam, analysis_type.
+        Sorted by sample name.
+    """
+    if not rows:
+        return pd.DataFrame(columns=["sample", "tumor_bam", "normal_bam", "analysis_type"])
+
+    df = pd.DataFrame(rows)[["sample", "tumor_bam", "normal_bam", "analysis_type"]]
+    return df.sort_values("sample").reset_index(drop=True)
+
+
+def print_bam_table(bam_entries: list[dict]) -> None:
+    """Pretty-print BAM discovery table with sizes and role guesses.
+
+    Args:
+        bam_entries: List of BAM entry dicts with basename, size_bytes, role, reason keys.
+    """
+    print(f"\nFound {len(bam_entries)} BAMs:\n")
+    # Calculate column widths
+    max_name = max((len(e["basename"]) for e in bam_entries), default=10)
+    max_size = max((len(format_size(e["size_bytes"])) for e in bam_entries), default=6)
+
+    fmt = f"  {{num:>3}}  {{name:<{max_name}}}  {{size:>{max_size}}}   {{role:<8}} {{reason}}"
+    for i, entry in enumerate(bam_entries, 1):
+        role = entry.get("role", "unknown")
+        reason = entry.get("reason", "")
+        display_role = role if role != "unknown" else "?"
+        print(
+            fmt.format(
+                num=i,
+                name=entry["basename"],
+                size=format_size(entry["size_bytes"]),
+                role=display_role,
+                reason=f"({reason})" if reason else "",
+            )
+        )
+    print()
+
+
+def print_samples_table(df: pd.DataFrame) -> None:
+    """Pretty-print the proposed/final samples.tsv with summary counts.
+
+    Args:
+        df: Samples DataFrame.
+    """
+    if df.empty:
+        print("  (no samples)")
+        return
+
+    print("\nProposed samples.tsv:\n")
+
+    # Column widths
+    col_widths: dict[str, int] = {}
+    for col in df.columns:
+        max_val = df[col].astype(str).str.len().max()
+        col_widths[col] = max(len(col), max_val)
+
+    # Header
+    header = "  #   " + "  ".join(col.ljust(col_widths[col]) for col in df.columns)
+    print(header)
+
+    # Rows
+    for i, (_, row) in enumerate(df.iterrows(), 1):
+        line = f"  {i:<3} " + "  ".join(
+            str(row[col]).ljust(col_widths[col]) for col in df.columns
+        )
+        print(line)
+
+    # Summary
+    counts = df["analysis_type"].value_counts()
+    summary_parts = [f"{count} {atype}" for atype, count in counts.items()]
+    print(f"\n  Summary: {', '.join(summary_parts)} ({len(df)} rows)")
+    print()
+
+
+def write_samples_tsv(
+    df: pd.DataFrame,
+    output_path: Path,
+    dry_run: bool = False,
+    force: bool = False,
+) -> None:
+    """Write the samples DataFrame to a TSV file.
+
+    Args:
+        df: Samples DataFrame.
+        output_path: Path for the output TSV.
+        dry_run: If True, do not write.
+        force: If True, overwrite without asking.
+    """
+    if dry_run:
+        print(f"[dry-run] Would write: {output_path} ({len(df)} rows)")
+        return
+
+    if output_path.is_file() and not force:
+        response = input(f"Output file already exists: {output_path}. Overwrite? [y/N] ")
+        if response.lower() not in ("y", "yes"):
+            print(f"Skipped writing {output_path}")
+            return
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    df.to_csv(output_path, sep="\t", index=False)
+    print(f"Written: {output_path} ({len(df)} rows)")
+
+
+# ---------------------------------------------------------------------------
+# Section G: Interactive + CLI
+# ---------------------------------------------------------------------------
+
+
+def _prompt(prompt: str, default: str = "") -> str:
+    """Prompt the user for input with an optional default value."""
+    if default:
+        result = input(f"{prompt} [{default}]: ").strip()
+        return result if result else default
+    return input(f"{prompt}: ").strip()
+
+
+def _prompt_yn(prompt: str, default: bool = True) -> bool:
+    """Prompt for yes/no with a default."""
+    suffix = "[Y/n]" if default else "[y/N]"
+    result = input(f"{prompt} {suffix}: ").strip().lower()
+    if not result:
+        return default
+    return result in ("y", "yes")
+
+
+def _prompt_path(prompt: str, default: str = "", must_exist: bool = True) -> str:
+    """Prompt for a filesystem path, re-prompting on invalid input."""
+    while True:
+        raw = _prompt(prompt, default)
+        if not raw:
+            if not must_exist:
+                return ""
+            print("  Path cannot be empty. Please try again.")
+            continue
+        p = Path(raw).expanduser()
+        if must_exist and not p.exists():
+            print(f"  Path does not exist: {p}")
+            retry = _prompt_yn("  Try again?", default=True)
+            if not retry:
+                return str(p)
+            continue
+        return str(p)
+
+
+def _prompt_choice(prompt: str, choices: list[str], default: str = "") -> str:
+    """Prompt with numbered choices.
+
+    Args:
+        prompt: Prompt text.
+        choices: List of choice strings.
+        default: Default choice value.
+
+    Returns:
+        Selected choice string.
+    """
+    for i, choice in enumerate(choices, 1):
+        marker = " <-- current" if choice == default else ""
+        print(f"    [{i}] {choice}{marker}")
+    while True:
+        raw = _prompt(f"  {prompt}", default=default)
+        # Accept by number
+        if raw.isdigit():
+            idx = int(raw) - 1
+            if 0 <= idx < len(choices):
+                return choices[idx]
+        # Accept by value
+        if raw in choices:
+            return raw
+        print(f"  Invalid choice. Enter 1-{len(choices)} or a value.")
+
+
+def prompt_unresolved_roles(bam_entries: list[dict]) -> list[dict]:
+    """Prompt user to classify BAMs with unknown roles.
+
+    Args:
+        bam_entries: BAM entry dicts. Entries with role='unknown' will be prompted.
+
+    Returns:
+        Updated bam_entries list with roles assigned.
+    """
+    unknowns = [e for e in bam_entries if e.get("role") == "unknown"]
+    if not unknowns:
+        return bam_entries
+
+    print(f"  {len(unknowns)} BAM(s) need manual role assignment.\n")
+    for entry in unknowns:
+        size = format_size(entry["size_bytes"])
+        while True:
+            raw = input(
+                f"  {entry['basename']} ({size}) -- T(umor) / N(ormal) / S(kip)? "
+            ).strip().upper()
+            if raw in ("T", "TUMOR"):
+                entry["role"] = "tumor"
+                entry["reason"] = "manual"
+                break
+            if raw in ("N", "NORMAL"):
+                entry["role"] = "normal"
+                entry["reason"] = "manual"
+                break
+            if raw in ("S", "SKIP"):
+                entry["role"] = "skip"
+                entry["reason"] = "skipped"
+                break
+            print("  Please enter T, N, or S.")
+
+    return bam_entries
+
+
+def _edit_row(df: pd.DataFrame, row_idx: int, bam_entries: list[dict]) -> pd.DataFrame:
+    """Edit a single row in the samples table interactively.
+
+    Args:
+        df: Current samples DataFrame.
+        row_idx: 0-based row index to edit.
+        bam_entries: BAM entries for listing available BAMs.
+
+    Returns:
+        Updated DataFrame.
+    """
+    row = df.iloc[row_idx]
+    available_bams = [e["basename"] for e in bam_entries if e.get("role") != "skip"]
+
+    print(
+        f"\n  Row {row_idx + 1}: {row['sample']}  "
+        f"tumor={row['tumor_bam']}  normal={row['normal_bam']}"
+    )
+
+    while True:
+        print("    [1] Change tumor BAM")
+        print("    [2] Change normal BAM")
+        print("    [3] Change analysis type")
+        print("    [4] Delete row")
+        print("    [5] Done editing this row")
+        choice = _prompt("  Select", default="5")
+
+        if choice == "1":
+            print("  Available BAMs:")
+            for i, bam in enumerate(available_bams, 1):
+                print(f"    [{i}] {bam}")
+            sel = _prompt("  Select BAM")
+            if sel.isdigit() and 1 <= int(sel) <= len(available_bams):
+                df.at[df.index[row_idx], "tumor_bam"] = available_bams[int(sel) - 1]
+            elif sel in available_bams:
+                df.at[df.index[row_idx], "tumor_bam"] = sel
+        elif choice == "2":
+            print("  Available BAMs (enter '.' for none):")
+            for i, bam in enumerate(available_bams, 1):
+                print(f"    [{i}] {bam}")
+            sel = _prompt("  Select BAM", default=".")
+            if sel == ".":
+                df.at[df.index[row_idx], "normal_bam"] = "."
+            elif sel.isdigit() and 1 <= int(sel) <= len(available_bams):
+                df.at[df.index[row_idx], "normal_bam"] = available_bams[int(sel) - 1]
+            elif sel in available_bams:
+                df.at[df.index[row_idx], "normal_bam"] = sel
+        elif choice == "3":
+            types = ["tumor_only", "tumor_normal", "germline"]
+            new_type = _prompt_choice("Analysis type", types, default=row["analysis_type"])
+            df.at[df.index[row_idx], "analysis_type"] = new_type
+        elif choice == "4":
+            df = df.drop(df.index[row_idx]).reset_index(drop=True)
+            print("  Row deleted.")
+            break
+        elif choice == "5":
+            break
+
+    return df
+
+
+def review_loop(
+    df: pd.DataFrame,
+    bam_entries: list[dict],
+    pairings: list[dict],
+    analysis_mode: str,
+) -> pd.DataFrame | None:
+    """Interactive review loop: Accept / Edit / Mode change / Quit.
+
+    Args:
+        df: Proposed samples DataFrame.
+        bam_entries: BAM entry dicts.
+        pairings: From group_and_pair().
+        analysis_mode: Current analysis mode.
+
+    Returns:
+        Final DataFrame, or None if user quits.
+    """
+    while True:
+        print_samples_table(df)
+        choice = _prompt("  [A]ccept / [E]dit rows / [M]ode change / [Q]uit", default="A")
+        choice = choice.upper()
+
+        if choice in ("A", "ACCEPT"):
+            return df
+
+        if choice in ("Q", "QUIT"):
+            return None
+
+        if choice in ("M", "MODE"):
+            modes = ["tumor_only", "tumor_normal", "both", "germline"]
+            new_mode = _prompt_choice("Analysis mode", modes, default=analysis_mode)
+            analysis_mode = new_mode
+            rows = generate_rows(pairings, bam_entries, analysis_mode)
+            df = build_samples_dataframe(rows)
+            continue
+
+        if choice in ("E", "EDIT"):
+            raw = _prompt("  Edit which row(s)? (comma-separated, e.g. 1,3)")
+            try:
+                indices = [int(x.strip()) - 1 for x in raw.split(",")]
+            except ValueError:
+                print("  Invalid input.")
+                continue
+            for idx in sorted(indices, reverse=True):
+                if 0 <= idx < len(df):
+                    df = _edit_row(df, idx, bam_entries)
+                else:
+                    print(f"  Row {idx + 1} out of range.")
+            continue
+
+
+def interactive_mode() -> None:
+    """Guided wizard for generating sm-calling config files."""
+    print()
+    print("=" * 60)
+    print("  sm-calling -- Config Generator")
+    print("=" * 60)
+    print()
+
+    # Phase 1: Scan + Propose
+    bam_folder = _prompt_path(
+        "BAM folder", default="results/exomes/bqsr"
+    )
+    bam_ext = _prompt("BAM extension", default=DEFAULT_BAM_EXTENSION)
+
+    bam_entries = discover_bam_files(bam_folder, bam_ext)
+
+    if not bam_entries:
+        # Check if there are any .bam files at all
+        bam_dir = Path(bam_folder)
+        if bam_dir.is_dir():
+            all_bams = [f for f in bam_dir.iterdir() if f.name.endswith(".bam")]
+            if all_bams:
+                print(
+                    f"\n  No BAMs matching '*{bam_ext}' found, "
+                    f"but {len(all_bams)} .bam file(s) exist."
+                )
+                print("  Try a different extension?")
+            else:
+                print(f"\n  No BAM files found in {bam_folder}")
+        else:
+            print(f"\n  Directory does not exist: {bam_folder}")
+        return
+
+    # Guess roles
+    for entry in bam_entries:
+        role, reason = guess_role(entry["basename"])
+        entry["role"] = role
+        entry["reason"] = reason
+
+    print_bam_table(bam_entries)
+
+    # Prompt for unresolved
+    bam_entries = prompt_unresolved_roles(bam_entries)
+
+    # Pair and generate rows
+    _patient_groups, pairings = group_and_pair(bam_entries)
+    analysis_mode = "both"
+    rows = generate_rows(pairings, bam_entries, analysis_mode)
+    df = build_samples_dataframe(rows)
+
+    # Phase 2: Review
+    df = review_loop(df, bam_entries, pairings, analysis_mode)
+    if df is None:
+        print("Quit without writing.")
+        return
+
+    # Phase 3: Write
+    samples_output = _prompt("Output samples.tsv", default="config/samples.tsv")
+    gen_config = _prompt_yn("Also generate config.yaml?", default=True)
+
+    caller = "mutect2"
+    scatter_mode = "chromosome"
+    ref_data: dict[str, Any] = {"genome": "", "build": "GRCh38", "search_log": []}
+    gatk_resources: dict[str, Any] = {
+        "panel_of_normals": "",
+        "af_only_gnomad": "",
+        "common_biallelic_gnomad": "",
+        "search_log": [],
+    }
+    config_output = "config/config.yaml"
+
+    if gen_config:
+        config_output = _prompt("Output config.yaml path", default="config/config.yaml")
+        caller = _prompt_choice(
+            "Caller", ["mutect2", "freebayes", "all"], default="mutect2"
+        )
+        scatter_mode = _prompt_choice(
+            "Scatter mode", ["chromosome", "interval", "none"], default="chromosome"
+        )
+
+        # Reference data discovery
+        print("\nScanning for reference data...")
+        project_root = Path(bam_folder).resolve().parent
+        ref_dir_str = _prompt_path(
+            "  Reference data directory (leave empty to auto-scan)",
+            must_exist=False,
+        )
+        ref_dir = Path(ref_dir_str).resolve() if ref_dir_str else None
+        ref_data = discover_reference_data(ref_dir, project_root)
+        for line in ref_data.get("search_log", []):
+            print(line)
+
+        # GATK resources
+        print("\nScanning for GATK resources...")
+        gatk_dir_str = _prompt_path(
+            "  GATK resource directory (leave empty to auto-scan)",
+            must_exist=False,
+        )
+        gatk_dir = Path(gatk_dir_str).resolve() if gatk_dir_str else None
+        gatk_resources = discover_gatk_resources(gatk_dir, project_root)
+        for line in gatk_resources.get("search_log", []):
+            print(line)
+
+    # Write files
+    output_path = Path(samples_output)
+    write_samples_tsv(df, output_path)
+
+    if gen_config:
+        output_folder = _prompt(
+            "Output folder for pipeline results",
+            default="results/exomes/variant_calls",
+        )
+        generate_config_template(
+            config_output=Path(config_output),
+            caller=caller,
+            ref_data=ref_data,
+            gatk_resources=gatk_resources,
+            bam_folder=bam_folder,
+            output_folder=output_folder,
+            samples_path=samples_output,
+            bam_extension=bam_ext,
+            scatter_mode=scatter_mode,
+        )
+
+    print("\nDone.")
+
+
+def main() -> None:
+    """Main entry point: parse arguments, discover files, generate output."""
+    parser = argparse.ArgumentParser(
+        description="Generate config/samples.tsv and config/config.yaml for sm-calling.\n"
+        "Run without arguments for an interactive guided wizard.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""\
+Examples:
+  %(prog)s                                                  # interactive wizard
+  %(prog)s --bam-folder /data/bams                          # auto-detect + write
+  %(prog)s --bam-folder /data/bams --dry-run                # preview only
+  %(prog)s --bam-folder /data/bams --config-template --caller mutect2
+  %(prog)s --bam-folder /data/bams --analysis-mode tumor_only --force
+        """,
+    )
+    parser.add_argument(
+        "--bam-folder",
+        help="Directory containing input BAM files (triggers non-interactive mode)",
+    )
+    parser.add_argument(
+        "--bam-extension",
+        default=DEFAULT_BAM_EXTENSION,
+        help=f"BAM file extension (default: {DEFAULT_BAM_EXTENSION})",
+    )
+    parser.add_argument(
+        "--analysis-mode",
+        choices=["auto", "tumor_only", "tumor_normal", "both", "germline"],
+        default="both",
+        help="Analysis mode (default: both). 'auto' tries heuristic pairing.",
+    )
+    parser.add_argument(
+        "--caller",
+        choices=["mutect2", "freebayes", "all"],
+        default="mutect2",
+        help="Variant caller for config.yaml (default: mutect2)",
+    )
+    parser.add_argument(
+        "--output",
+        default="config/samples.tsv",
+        help="Output samples.tsv path (default: config/samples.tsv)",
+    )
+    parser.add_argument(
+        "--config-template",
+        action="store_true",
+        help="Also generate a config.yaml file",
+    )
+    parser.add_argument(
+        "--config-output",
+        default="config/config.yaml",
+        help="Output config.yaml path (default: config/config.yaml)",
+    )
+    parser.add_argument(
+        "--ref-dir",
+        help="Reference genome directory",
+    )
+    parser.add_argument(
+        "--gatk-resource-dir",
+        help="GATK resource VCF directory",
+    )
+    parser.add_argument(
+        "--scatter-mode",
+        choices=["chromosome", "interval", "none"],
+        default="chromosome",
+        help="Scatter mode (default: chromosome)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show output without writing files",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Overwrite existing files without asking",
+    )
+
+    args = parser.parse_args()
+
+    # No --bam-folder -> interactive mode
+    if not args.bam_folder:
+        interactive_mode()
+        return
+
+    bam_folder = Path(args.bam_folder).resolve()
+
+    # Discover BAMs
+    bam_entries = discover_bam_files(str(bam_folder), args.bam_extension)
+
+    if not bam_entries:
+        bam_dir = Path(bam_folder)
+        if bam_dir.is_dir():
+            all_bams = [f for f in bam_dir.iterdir() if f.name.endswith(".bam")]
+            if all_bams:
+                sys.exit(
+                    f"Error: No BAMs matching '*{args.bam_extension}' in {bam_folder}\n"
+                    f"Found {len(all_bams)} .bam file(s). Try --bam-extension."
+                )
+        sys.exit(f"Error: No BAM files found in {bam_folder}")
+
+    # Guess roles
+    for entry in bam_entries:
+        role, reason = guess_role(entry["basename"])
+        entry["role"] = role
+        entry["reason"] = reason
+
+    # Check for unknowns in CLI mode
+    unknowns = [e for e in bam_entries if e["role"] == "unknown"]
+    if unknowns and args.analysis_mode != "germline":
+        unknown_names = ", ".join(e["basename"] for e in unknowns)
+        print(
+            f"Warning: {len(unknowns)} BAM(s) with unrecognized role: {unknown_names}",
+            file=sys.stderr,
+        )
+        print("  These will be skipped. Use interactive mode for manual assignment.", file=sys.stderr)
+        # In CLI mode, skip unknowns
+        for e in unknowns:
+            e["role"] = "skip"
+
+    # Analysis mode
+    analysis_mode = args.analysis_mode
+    if analysis_mode == "auto":
+        analysis_mode = "both"
+
+    # Pair and generate
+    _patient_groups, pairings = group_and_pair(bam_entries)
+
+    # Check for ambiguous pairings in CLI auto mode
+    if args.analysis_mode == "auto":
+        tumors = [e for e in bam_entries if e["role"] == "tumor"]
+        normals = [e for e in bam_entries if e["role"] == "normal"]
+        if len(tumors) > 1 and len(normals) > 1:
+            # Check if pairing is ambiguous (multiple normals available per tumor)
+            for pairing in pairings:
+                if pairing["normal"] is None and normals:
+                    sys.exit(
+                        "Error: Ambiguous tumor-normal pairing detected.\n"
+                        "Use interactive mode or specify --analysis-mode explicitly."
+                    )
+
+    rows = generate_rows(pairings, bam_entries, analysis_mode)
+    df = build_samples_dataframe(rows)
+
+    print_bam_table(bam_entries)
+    print_samples_table(df)
+
+    # Write samples.tsv
+    write_samples_tsv(df, Path(args.output), dry_run=args.dry_run, force=args.force)
+
+    # Generate config template
+    if args.config_template:
+        ref_dir = Path(args.ref_dir).resolve() if args.ref_dir else None
+        gatk_dir = Path(args.gatk_resource_dir).resolve() if args.gatk_resource_dir else None
+        project_root = bam_folder.parent
+
+        print("Scanning for reference data...")
+        ref_data = discover_reference_data(ref_dir, project_root)
+        for line in ref_data.get("search_log", []):
+            print(line)
+
+        print("Scanning for GATK resources...")
+        gatk_resources = discover_gatk_resources(gatk_dir, project_root)
+        for line in gatk_resources.get("search_log", []):
+            print(line)
+        print()
+
+        generate_config_template(
+            config_output=Path(args.config_output),
+            caller=args.caller,
+            ref_data=ref_data,
+            gatk_resources=gatk_resources,
+            bam_folder=str(bam_folder),
+            output_folder="results/exomes/variant_calls",
+            samples_path=args.output,
+            bam_extension=args.bam_extension,
+            scatter_mode=args.scatter_mode,
+            dry_run=args.dry_run,
+            force=args.force,
+        )
+
+    print("\nDone.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_generate_config.py
+++ b/tests/test_generate_config.py
@@ -1,0 +1,789 @@
+"""Unit tests for scripts/generate_config.py."""
+
+import os
+import sys
+
+import pandas as pd
+import pytest
+
+# Add scripts/ to path so generate_config can be imported
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
+
+from generate_config import (
+    _build_config_yaml,
+    _find_gatk_resource_vcfs,
+    _find_genome_fastas,
+    build_samples_dataframe,
+    discover_bam_files,
+    discover_gatk_resources,
+    discover_reference_data,
+    extract_patient_id,
+    find_best_normal,
+    format_size,
+    generate_rows,
+    generate_sample_name,
+    group_and_pair,
+    guess_role,
+    write_samples_tsv,
+)
+
+# ---------------------------------------------------------------------------
+# TestDiscoverBamFiles
+# ---------------------------------------------------------------------------
+
+
+class TestDiscoverBamFiles:
+    def test_finds_bams_with_extension(self, tmp_path):
+        (tmp_path / "sample1.merged.dedup.bqsr.bam").write_bytes(b"x" * 100)
+        (tmp_path / "sample2.merged.dedup.bqsr.bam").write_bytes(b"x" * 200)
+        result = discover_bam_files(str(tmp_path), ".merged.dedup.bqsr.bam")
+        assert len(result) == 2
+        basenames = [r["basename"] for r in result]
+        assert "sample1" in basenames
+        assert "sample2" in basenames
+
+    def test_ignores_wrong_extension(self, tmp_path):
+        (tmp_path / "sample1.merged.dedup.bqsr.bam").write_bytes(b"x" * 100)
+        (tmp_path / "sample2.sorted.bam").write_bytes(b"x" * 200)
+        result = discover_bam_files(str(tmp_path), ".merged.dedup.bqsr.bam")
+        assert len(result) == 1
+        assert result[0]["basename"] == "sample1"
+
+    def test_detects_bai_index(self, tmp_path):
+        (tmp_path / "sample1.merged.dedup.bqsr.bam").write_bytes(b"x" * 100)
+        (tmp_path / "sample1.merged.dedup.bqsr.bam.bai").write_bytes(b"x")
+        result = discover_bam_files(str(tmp_path), ".merged.dedup.bqsr.bam")
+        assert result[0]["has_index"] is True
+
+    def test_no_index_detected(self, tmp_path):
+        (tmp_path / "sample1.merged.dedup.bqsr.bam").write_bytes(b"x" * 100)
+        result = discover_bam_files(str(tmp_path), ".merged.dedup.bqsr.bam")
+        assert result[0]["has_index"] is False
+
+    def test_returns_size(self, tmp_path):
+        (tmp_path / "sample1.merged.dedup.bqsr.bam").write_bytes(b"x" * 12345)
+        result = discover_bam_files(str(tmp_path), ".merged.dedup.bqsr.bam")
+        assert result[0]["size_bytes"] == 12345
+
+    def test_empty_directory(self, tmp_path):
+        result = discover_bam_files(str(tmp_path), ".merged.dedup.bqsr.bam")
+        assert result == []
+
+    def test_nonexistent_directory(self):
+        result = discover_bam_files("/nonexistent/path", ".bam")
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# TestFormatSize
+# ---------------------------------------------------------------------------
+
+
+class TestFormatSize:
+    def test_gigabytes(self):
+        assert format_size(45_300_000_000) == "45.3 GB"
+
+    def test_megabytes(self):
+        assert format_size(512_000_000) == "512.0 MB"
+
+    def test_kilobytes(self):
+        assert format_size(1500) == "1.5 KB"
+
+    def test_bytes(self):
+        assert format_size(500) == "500 B"
+
+
+# ---------------------------------------------------------------------------
+# TestGuessRole
+# ---------------------------------------------------------------------------
+
+
+class TestGuessRole:
+    # Tumor patterns
+    def test_dash_T(self):
+        role, reason = guess_role("APA1-T")
+        assert role == "tumor"
+
+    def test_dash_T1(self):
+        role, _ = guess_role("APA1-T1")
+        assert role == "tumor"
+
+    def test_underscore_tumor(self):
+        role, _ = guess_role("SAMPLE_tumor")
+        assert role == "tumor"
+
+    def test_dot_FFPE(self):
+        role, _ = guess_role("SAMPLE.FFPE")
+        assert role == "tumor"
+
+    def test_suffix_met(self):
+        role, _ = guess_role("SAMPLE-met")
+        assert role == "tumor"
+
+    def test_suffix_primary(self):
+        role, _ = guess_role("SAMPLE_primary")
+        assert role == "tumor"
+
+    # Normal patterns
+    def test_dash_N(self):
+        role, _ = guess_role("APA1-N")
+        assert role == "normal"
+
+    def test_suffix_N1(self):
+        role, _ = guess_role("A5297_DNA_02_STREAM_P1_N1")
+        assert role == "normal"
+
+    def test_suffix_normal(self):
+        role, _ = guess_role("SAMPLE_normal")
+        assert role == "normal"
+
+    def test_suffix_blood(self):
+        role, _ = guess_role("SAMPLE-blood")
+        assert role == "normal"
+
+    def test_suffix_germline(self):
+        role, _ = guess_role("SAMPLE.germline")
+        assert role == "normal"
+
+    # Unknown
+    def test_unknown_no_match(self):
+        role, reason = guess_role("A5297_DNA_01_STREAM_P1_L1")
+        assert role == "unknown"
+        assert "no pattern" in reason
+
+    # No false positives
+    def test_no_false_positive_ント(self):
+        """Internal 'N' should not match."""
+        role, _ = guess_role("INTERNAL_NAME")
+        assert role == "unknown"
+
+    def test_no_false_positive_T_in_middle(self):
+        """Internal 'T' should not match."""
+        role, _ = guess_role("TOTALLY_FINE")
+        assert role == "unknown"
+
+    def test_case_insensitive_tumor(self):
+        role, _ = guess_role("SAMPLE-Tumor")
+        assert role == "tumor"
+
+    def test_case_insensitive_normal(self):
+        role, _ = guess_role("SAMPLE_Normal")
+        assert role == "normal"
+
+
+# ---------------------------------------------------------------------------
+# TestExtractPatientId
+# ---------------------------------------------------------------------------
+
+
+class TestExtractPatientId:
+    def test_strips_T_suffix(self):
+        assert extract_patient_id("APA1-T") == "APA1"
+
+    def test_strips_N_suffix(self):
+        assert extract_patient_id("APA1-N") == "APA1"
+
+    def test_strips_tumor_suffix(self):
+        assert extract_patient_id("SAMPLE_tumor") == "SAMPLE"
+
+    def test_strips_normal_suffix(self):
+        assert extract_patient_id("SAMPLE_normal") == "SAMPLE"
+
+    def test_strips_N1_suffix(self):
+        assert extract_patient_id("A5297_DNA_02_STREAM_P1_N1") == "A5297_DNA_02_STREAM_P1"
+
+    def test_no_suffix_passthrough(self):
+        assert extract_patient_id("A5297_DNA_01_STREAM_P1_L1") == "A5297_DNA_01_STREAM_P1_L1"
+
+    def test_strips_blood_suffix(self):
+        assert extract_patient_id("SAMPLE-blood") == "SAMPLE"
+
+    def test_strips_FFPE(self):
+        assert extract_patient_id("SAMPLE.FFPE") == "SAMPLE"
+
+
+# ---------------------------------------------------------------------------
+# TestFindBestNormal
+# ---------------------------------------------------------------------------
+
+
+class TestFindBestNormal:
+    def test_same_patient_priority(self):
+        normals = ["APA1-N", "APA2-N"]
+        result = find_best_normal("APA1-T", normals, patient_groups={"APA1": {}})
+        assert result == "APA1-N"
+
+    def test_string_similarity(self):
+        normals = ["A5297_DNA_02_STREAM_P1_N1"]
+        result = find_best_normal("A5297_DNA_01_STREAM_P1_L1", normals)
+        assert result == "A5297_DNA_02_STREAM_P1_N1"
+
+    def test_no_match_below_threshold(self):
+        normals = ["COMPLETELY_DIFFERENT"]
+        result = find_best_normal("APA1-T", normals)
+        assert result is None
+
+    def test_empty_normals(self):
+        result = find_best_normal("APA1-T", [])
+        assert result is None
+
+    def test_best_of_multiple(self):
+        normals = ["APA1-N", "APA2-N", "APA3-N"]
+        result = find_best_normal("APA1-T", normals)
+        assert result == "APA1-N"
+
+    def test_patient_groups_preferred(self):
+        normals = ["APA2-N", "APA1-N"]
+        groups = {
+            "APA1": {"tumors": ["APA1-T"], "normals": ["APA1-N"]},
+            "APA2": {"tumors": [], "normals": ["APA2-N"]},
+        }
+        result = find_best_normal("APA1-T", normals, patient_groups=groups)
+        assert result == "APA1-N"
+
+
+# ---------------------------------------------------------------------------
+# TestGroupAndPair
+# ---------------------------------------------------------------------------
+
+
+class TestGroupAndPair:
+    def test_simple_pair(self):
+        entries = [
+            {"basename": "APA1-T", "role": "tumor"},
+            {"basename": "APA1-N", "role": "normal"},
+        ]
+        groups, pairings = group_and_pair(entries)
+        assert len(pairings) == 1
+        assert pairings[0]["tumor"] == "APA1-T"
+        assert pairings[0]["normal"] == "APA1-N"
+
+    def test_tumor_only(self):
+        entries = [
+            {"basename": "APA1-T", "role": "tumor"},
+        ]
+        _, pairings = group_and_pair(entries)
+        assert len(pairings) == 1
+        assert pairings[0]["normal"] is None
+
+    def test_multiple_patients(self):
+        entries = [
+            {"basename": "APA1-T", "role": "tumor"},
+            {"basename": "APA1-N", "role": "normal"},
+            {"basename": "APA2-T", "role": "tumor"},
+            {"basename": "APA2-N", "role": "normal"},
+        ]
+        _, pairings = group_and_pair(entries)
+        assert len(pairings) == 2
+
+        # APA1-T should be paired with APA1-N
+        apa1 = next(p for p in pairings if p["tumor"] == "APA1-T")
+        assert apa1["normal"] == "APA1-N"
+
+        # APA2-T should be paired with APA2-N
+        apa2 = next(p for p in pairings if p["tumor"] == "APA2-T")
+        assert apa2["normal"] == "APA2-N"
+
+    def test_skipped_entries_excluded(self):
+        entries = [
+            {"basename": "APA1-T", "role": "tumor"},
+            {"basename": "SKIP_ME", "role": "skip"},
+        ]
+        _, pairings = group_and_pair(entries)
+        assert len(pairings) == 1
+
+    def test_complex_names_pair(self):
+        entries = [
+            {"basename": "A5297_DNA_01_STREAM_P1_L1", "role": "tumor"},
+            {"basename": "A5297_DNA_02_STREAM_P1_N1", "role": "normal"},
+        ]
+        _, pairings = group_and_pair(entries)
+        assert len(pairings) == 1
+        # These should pair via string similarity
+        assert pairings[0]["normal"] == "A5297_DNA_02_STREAM_P1_N1"
+
+    def test_patient_groups_populated(self):
+        entries = [
+            {"basename": "APA1-T", "role": "tumor"},
+            {"basename": "APA1-N", "role": "normal"},
+        ]
+        groups, _ = group_and_pair(entries)
+        assert "APA1" in groups
+        assert "APA1-T" in groups["APA1"]["tumors"]
+        assert "APA1-N" in groups["APA1"]["normals"]
+
+    def test_multiple_tumors_one_normal(self):
+        entries = [
+            {"basename": "APA1-T1", "role": "tumor"},
+            {"basename": "APA1-T2", "role": "tumor"},
+            {"basename": "APA1-N", "role": "normal"},
+        ]
+        _, pairings = group_and_pair(entries)
+        assert len(pairings) == 2
+        # One tumor should get the normal, the other should not
+        normals_used = [p["normal"] for p in pairings if p["normal"] is not None]
+        assert len(normals_used) == 1
+        assert normals_used[0] == "APA1-N"
+
+    def test_no_tumors(self):
+        entries = [
+            {"basename": "APA1-N", "role": "normal"},
+        ]
+        _, pairings = group_and_pair(entries)
+        assert len(pairings) == 0
+
+
+# ---------------------------------------------------------------------------
+# TestGenerateRows
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateRows:
+    @pytest.fixture
+    def simple_pairings(self):
+        return [
+            {"tumor": "APA1-T", "normal": "APA1-N", "patient_id": "APA1"},
+        ]
+
+    @pytest.fixture
+    def simple_entries(self):
+        return [
+            {"basename": "APA1-T", "role": "tumor"},
+            {"basename": "APA1-N", "role": "normal"},
+        ]
+
+    def test_both_mode(self, simple_pairings, simple_entries):
+        rows = generate_rows(simple_pairings, simple_entries, "both")
+        assert len(rows) == 2
+        types = [r["analysis_type"] for r in rows]
+        assert "tumor_only" in types
+        assert "tumor_normal" in types
+
+    def test_tumor_only_mode(self, simple_pairings, simple_entries):
+        rows = generate_rows(simple_pairings, simple_entries, "tumor_only")
+        assert len(rows) == 1
+        assert rows[0]["analysis_type"] == "tumor_only"
+        assert rows[0]["normal_bam"] == "."
+
+    def test_tumor_normal_mode(self, simple_pairings, simple_entries):
+        rows = generate_rows(simple_pairings, simple_entries, "tumor_normal")
+        assert len(rows) == 1
+        assert rows[0]["analysis_type"] == "tumor_normal"
+        assert rows[0]["normal_bam"] == "APA1-N"
+
+    def test_germline_mode(self, simple_pairings, simple_entries):
+        rows = generate_rows(simple_pairings, simple_entries, "germline")
+        assert len(rows) == 2
+        for row in rows:
+            assert row["analysis_type"] == "germline"
+
+    def test_unpaired_tumor_in_tn_mode(self):
+        pairings = [{"tumor": "APA1-T", "normal": None, "patient_id": "APA1"}]
+        entries = [{"basename": "APA1-T", "role": "tumor"}]
+        rows = generate_rows(pairings, entries, "tumor_normal")
+        assert len(rows) == 0  # No TN row without normal
+
+    def test_mixed_patients(self):
+        pairings = [
+            {"tumor": "APA1-T", "normal": "APA1-N", "patient_id": "APA1"},
+            {"tumor": "APA2-T", "normal": None, "patient_id": "APA2"},
+        ]
+        entries = [
+            {"basename": "APA1-T", "role": "tumor"},
+            {"basename": "APA1-N", "role": "normal"},
+            {"basename": "APA2-T", "role": "tumor"},
+        ]
+        rows = generate_rows(pairings, entries, "both")
+        # APA1: To + TN, APA2: To only
+        assert len(rows) == 3
+
+
+# ---------------------------------------------------------------------------
+# TestGenerateSampleName
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateSampleName:
+    def test_tumor_normal_suffix(self):
+        assert generate_sample_name("APA1", "tumor_normal", 0, 1) == "APA1_TN"
+
+    def test_tumor_only_suffix(self):
+        assert generate_sample_name("APA1", "tumor_only", 0, 1) == "APA1_To"
+
+    def test_germline_suffix(self):
+        assert generate_sample_name("APA1", "germline", 0, 1) == "APA1_G"
+
+    def test_disambiguation_index(self):
+        assert generate_sample_name("APA1", "tumor_normal", 0, 2) == "APA1_TN_1"
+        assert generate_sample_name("APA1", "tumor_normal", 1, 2) == "APA1_TN_2"
+
+    def test_single_no_index(self):
+        name = generate_sample_name("APA1", "tumor_only", 0, 1)
+        assert "_1" not in name
+
+
+# ---------------------------------------------------------------------------
+# TestGatkResourceDiscovery
+# ---------------------------------------------------------------------------
+
+
+class TestGatkResourceDiscovery:
+    def test_finds_pon(self, tmp_path):
+        (tmp_path / "1000g_pon.hg38.vcf.gz").write_bytes(b"x")
+        result = _find_gatk_resource_vcfs(tmp_path, "panel_of_normals", ["*pon*.vcf*"])
+        assert len(result) == 1
+        assert "1000g_pon" in result[0]
+
+    def test_excludes_tbi(self, tmp_path):
+        (tmp_path / "1000g_pon.hg38.vcf.gz").write_bytes(b"x")
+        (tmp_path / "1000g_pon.hg38.vcf.gz.tbi").write_bytes(b"x")
+        result = _find_gatk_resource_vcfs(tmp_path, "panel_of_normals", ["*pon*.vcf*"])
+        assert len(result) == 1
+        assert not result[0].endswith(".tbi")
+
+    def test_af_gnomad_excludes_common(self, tmp_path):
+        (tmp_path / "af-only-gnomad.hg38.vcf.gz").write_bytes(b"x")
+        (tmp_path / "af-only-gnomad.hg38.common_biallelic.vcf.gz").write_bytes(b"x")
+        result = _find_gatk_resource_vcfs(
+            tmp_path, "af_only_gnomad", ["*af-only-gnomad*.vcf*"]
+        )
+        assert len(result) == 1
+        # Check the filename only, not the full path (temp dirs may contain "common")
+        from pathlib import Path
+
+        assert "common" not in Path(result[0]).name
+
+    def test_common_biallelic_found(self, tmp_path):
+        (tmp_path / "af-only-gnomad.hg38.common_biallelic.vcf.gz").write_bytes(b"x")
+        result = _find_gatk_resource_vcfs(
+            tmp_path, "common_biallelic_gnomad", ["*common_biallelic*.vcf*"]
+        )
+        assert len(result) == 1
+
+    def test_empty_dir(self, tmp_path):
+        result = _find_gatk_resource_vcfs(tmp_path, "panel_of_normals", ["*pon*.vcf*"])
+        assert result == []
+
+    def test_nonexistent_dir(self):
+        from pathlib import Path
+
+        result = _find_gatk_resource_vcfs(Path("/nonexistent"), "panel_of_normals", ["*pon*.vcf*"])
+        assert result == []
+
+
+class TestDiscoverGatkResources:
+    def test_finds_all_resources(self, tmp_path):
+        (tmp_path / "1000g_pon.hg38.vcf.gz").write_bytes(b"x")
+        (tmp_path / "af-only-gnomad.hg38.vcf.gz").write_bytes(b"x")
+        (tmp_path / "af-only-gnomad.hg38.common_biallelic.vcf.gz").write_bytes(b"x")
+        result = discover_gatk_resources(tmp_path)
+        assert result["panel_of_normals"] != ""
+        assert result["af_only_gnomad"] != ""
+        assert result["common_biallelic_gnomad"] != ""
+
+    def test_missing_resources_logged(self, tmp_path):
+        result = discover_gatk_resources(tmp_path)
+        assert any("not found" in line for line in result["search_log"])
+
+
+# ---------------------------------------------------------------------------
+# TestReferenceDiscovery
+# ---------------------------------------------------------------------------
+
+
+class TestReferenceDiscovery:
+    def test_finds_fasta(self, tmp_path):
+        (tmp_path / "genome.fna").write_bytes(b"x")
+        (tmp_path / "genome.fna.fai").write_bytes(b"x")
+        result = discover_reference_data(tmp_path)
+        assert result["genome"] != ""
+
+    def test_detects_grch38(self, tmp_path):
+        (tmp_path / "GRCh38.fna").write_bytes(b"x")
+        result = discover_reference_data(tmp_path)
+        assert result["build"] == "GRCh38"
+
+    def test_detects_grch37(self, tmp_path):
+        (tmp_path / "hs37d5.fasta").write_bytes(b"x")
+        result = discover_reference_data(tmp_path)
+        assert result["build"] == "GRCh37"
+
+    def test_no_genome_found(self, tmp_path):
+        result = discover_reference_data(tmp_path)
+        assert result["genome"] == ""
+        assert any("No reference genome" in line for line in result["search_log"])
+
+
+class TestFindGenomeFastas:
+    def test_finds_multiple_extensions(self, tmp_path):
+        (tmp_path / "genome.fna").write_bytes(b"x")
+        (tmp_path / "genome.fa").write_bytes(b"x")
+        result = _find_genome_fastas(tmp_path)
+        assert len(result) == 2
+
+    def test_checks_fai(self, tmp_path):
+        (tmp_path / "genome.fna").write_bytes(b"x")
+        (tmp_path / "genome.fna.fai").write_bytes(b"x")
+        result = _find_genome_fastas(tmp_path)
+        assert result[0]["has_fai"] is True
+
+    def test_skips_hidden(self, tmp_path):
+        (tmp_path / ".hidden.fna").write_bytes(b"x")
+        result = _find_genome_fastas(tmp_path)
+        assert len(result) == 0
+
+    def test_nonexistent_dir(self):
+        from pathlib import Path
+
+        result = _find_genome_fastas(Path("/nonexistent"))
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# TestBuildConfigYaml
+# ---------------------------------------------------------------------------
+
+
+class TestBuildConfigYaml:
+    @pytest.fixture
+    def ref_data(self):
+        return {"genome": "/ref/GRCh38.fna", "build": "GRCh38"}
+
+    @pytest.fixture
+    def gatk_resources(self):
+        return {
+            "panel_of_normals": "/res/pon.vcf.gz",
+            "af_only_gnomad": "/res/gnomad.vcf.gz",
+            "common_biallelic_gnomad": "/res/common.vcf.gz",
+        }
+
+    def test_contains_caller(self, ref_data, gatk_resources):
+        content = _build_config_yaml(
+            "mutect2", ref_data, gatk_resources,
+            "/bams", "/output", "config/samples.tsv",
+            ".bam", "chromosome",
+        )
+        assert 'caller: "mutect2"' in content
+
+    def test_contains_ref(self, ref_data, gatk_resources):
+        content = _build_config_yaml(
+            "mutect2", ref_data, gatk_resources,
+            "/bams", "/output", "config/samples.tsv",
+            ".bam", "chromosome",
+        )
+        assert "genome:" in content
+        assert "GRCh38" in content
+
+    def test_contains_gatk_resources(self, ref_data, gatk_resources):
+        content = _build_config_yaml(
+            "mutect2", ref_data, gatk_resources,
+            "/bams", "/output", "config/samples.tsv",
+            ".bam", "chromosome",
+        )
+        assert "panel_of_normals:" in content
+        assert "af_only_gnomad:" in content
+        assert "common_biallelic_gnomad:" in content
+
+    def test_contains_scatter(self, ref_data, gatk_resources):
+        content = _build_config_yaml(
+            "mutect2", ref_data, gatk_resources,
+            "/bams", "/output", "config/samples.tsv",
+            ".bam", "chromosome",
+        )
+        assert 'mode: "chromosome"' in content
+        assert "chr1" in content
+        assert "chrY" in content
+
+    def test_edit_me_placeholders(self):
+        content = _build_config_yaml(
+            "mutect2",
+            {"genome": "", "build": "GRCh38"},
+            {"panel_of_normals": "", "af_only_gnomad": "", "common_biallelic_gnomad": ""},
+            "/bams", "/output", "config/samples.tsv",
+            ".bam", "chromosome",
+        )
+        assert "EDIT_ME" in content
+
+
+# ---------------------------------------------------------------------------
+# TestBuildSamplesDataframe
+# ---------------------------------------------------------------------------
+
+
+class TestBuildSamplesDataframe:
+    def test_correct_columns(self):
+        rows = [
+            {"sample": "S1_TN", "tumor_bam": "S1-T", "normal_bam": "S1-N",
+             "analysis_type": "tumor_normal", "patient_id": "S1"},
+        ]
+        df = build_samples_dataframe(rows)
+        assert list(df.columns) == ["sample", "tumor_bam", "normal_bam", "analysis_type"]
+
+    def test_sorted_by_sample(self):
+        rows = [
+            {"sample": "B_TN", "tumor_bam": "B-T", "normal_bam": "B-N",
+             "analysis_type": "tumor_normal", "patient_id": "B"},
+            {"sample": "A_To", "tumor_bam": "A-T", "normal_bam": ".",
+             "analysis_type": "tumor_only", "patient_id": "A"},
+        ]
+        df = build_samples_dataframe(rows)
+        assert df.iloc[0]["sample"] == "A_To"
+        assert df.iloc[1]["sample"] == "B_TN"
+
+    def test_dot_sentinel_preserved(self):
+        rows = [
+            {"sample": "S1_To", "tumor_bam": "S1-T", "normal_bam": ".",
+             "analysis_type": "tumor_only", "patient_id": "S1"},
+        ]
+        df = build_samples_dataframe(rows)
+        assert df.iloc[0]["normal_bam"] == "."
+
+    def test_empty_rows(self):
+        df = build_samples_dataframe([])
+        assert len(df) == 0
+        assert list(df.columns) == ["sample", "tumor_bam", "normal_bam", "analysis_type"]
+
+
+# ---------------------------------------------------------------------------
+# Integration-style tests: end-to-end row generation
+# ---------------------------------------------------------------------------
+
+
+class TestEndToEndGeneration:
+    """Test the full pipeline from BAM entries to sample rows."""
+
+    def test_simple_pair_both_mode(self):
+        entries = [
+            {"basename": "APA1-T", "role": "tumor"},
+            {"basename": "APA1-N", "role": "normal"},
+        ]
+        _, pairings = group_and_pair(entries)
+        rows = generate_rows(pairings, entries, "both")
+        df = build_samples_dataframe(rows)
+
+        assert len(df) == 2
+        to_row = df[df["analysis_type"] == "tumor_only"].iloc[0]
+        assert to_row["tumor_bam"] == "APA1-T"
+        assert to_row["normal_bam"] == "."
+
+        tn_row = df[df["analysis_type"] == "tumor_normal"].iloc[0]
+        assert tn_row["tumor_bam"] == "APA1-T"
+        assert tn_row["normal_bam"] == "APA1-N"
+
+    def test_complex_names(self):
+        entries = [
+            {"basename": "A5297_DNA_01_STREAM_P1_L1", "role": "tumor"},
+            {"basename": "A5297_DNA_02_STREAM_P1_N1", "role": "normal"},
+        ]
+        _, pairings = group_and_pair(entries)
+        rows = generate_rows(pairings, entries, "both")
+        df = build_samples_dataframe(rows)
+
+        assert len(df) == 2
+        tn_rows = df[df["analysis_type"] == "tumor_normal"]
+        assert len(tn_rows) == 1
+        assert tn_rows.iloc[0]["normal_bam"] == "A5297_DNA_02_STREAM_P1_N1"
+
+    def test_germline_mode_all_bams(self):
+        entries = [
+            {"basename": "APA1-T", "role": "tumor"},
+            {"basename": "APA1-N", "role": "normal"},
+            {"basename": "APA2-T", "role": "tumor"},
+        ]
+        _, pairings = group_and_pair(entries)
+        rows = generate_rows(pairings, entries, "germline")
+        df = build_samples_dataframe(rows)
+
+        assert len(df) == 3
+        assert all(df["analysis_type"] == "germline")
+
+    def test_multiple_patients_both(self):
+        entries = [
+            {"basename": "APA1-T", "role": "tumor"},
+            {"basename": "APA1-N", "role": "normal"},
+            {"basename": "APA2-T", "role": "tumor"},
+            {"basename": "APA2-N", "role": "normal"},
+        ]
+        _, pairings = group_and_pair(entries)
+        rows = generate_rows(pairings, entries, "both")
+        df = build_samples_dataframe(rows)
+
+        # 2 patients x (1 To + 1 TN) = 4 rows
+        assert len(df) == 4
+        assert len(df[df["analysis_type"] == "tumor_only"]) == 2
+        assert len(df[df["analysis_type"] == "tumor_normal"]) == 2
+
+    def test_tumor_no_normal(self):
+        entries = [
+            {"basename": "APA1-T", "role": "tumor"},
+        ]
+        _, pairings = group_and_pair(entries)
+        rows = generate_rows(pairings, entries, "both")
+        df = build_samples_dataframe(rows)
+
+        # Only tumor_only row (no normal for TN)
+        assert len(df) == 1
+        assert df.iloc[0]["analysis_type"] == "tumor_only"
+
+    def test_skipped_bams_excluded(self):
+        entries = [
+            {"basename": "APA1-T", "role": "tumor"},
+            {"basename": "APA1-N", "role": "normal"},
+            {"basename": "SKIP_ME", "role": "skip"},
+        ]
+        _, pairings = group_and_pair(entries)
+        rows = generate_rows(pairings, entries, "both")
+        df = build_samples_dataframe(rows)
+
+        bam_names = list(df["tumor_bam"]) + list(df["normal_bam"])
+        assert "SKIP_ME" not in bam_names
+
+
+# ---------------------------------------------------------------------------
+# Test write/output functions
+# ---------------------------------------------------------------------------
+
+
+class TestWriteSamplesTsv:
+    def test_dry_run_no_file(self, tmp_path, capsys):
+        df = pd.DataFrame(
+            {"sample": ["S1"], "tumor_bam": ["T1"], "normal_bam": ["."],
+             "analysis_type": ["tumor_only"]}
+        )
+        out = tmp_path / "samples.tsv"
+        write_samples_tsv(df, out, dry_run=True)
+        assert not out.exists()
+        assert "dry-run" in capsys.readouterr().out
+
+    def test_writes_file(self, tmp_path):
+        df = pd.DataFrame(
+            {"sample": ["S1"], "tumor_bam": ["T1"], "normal_bam": ["."],
+             "analysis_type": ["tumor_only"]}
+        )
+        out = tmp_path / "samples.tsv"
+        write_samples_tsv(df, out, force=True)
+        assert out.exists()
+        content = out.read_text()
+        assert "S1" in content
+        assert "tumor_only" in content
+
+    def test_creates_parent_dirs(self, tmp_path):
+        df = pd.DataFrame(
+            {"sample": ["S1"], "tumor_bam": ["T1"], "normal_bam": ["."],
+             "analysis_type": ["tumor_only"]}
+        )
+        out = tmp_path / "subdir" / "samples.tsv"
+        write_samples_tsv(df, out, force=True)
+        assert out.exists()
+
+    def test_tsv_format(self, tmp_path):
+        df = pd.DataFrame(
+            {"sample": ["S1", "S2"], "tumor_bam": ["T1", "T2"],
+             "normal_bam": [".", "N2"], "analysis_type": ["tumor_only", "tumor_normal"]}
+        )
+        out = tmp_path / "samples.tsv"
+        write_samples_tsv(df, out, force=True)
+        # Read back and verify tab-separated
+        loaded = pd.read_csv(out, sep="\t")
+        assert list(loaded.columns) == ["sample", "tumor_bam", "normal_bam", "analysis_type"]
+        assert len(loaded) == 2


### PR DESCRIPTION
## Summary

- **`scripts/generate_config.py`** — scans BAM directories, classifies tumor/normal roles by filename heuristics, pairs tumors with normals, and generates `config/samples.tsv` + `config/config.yaml`. Supports interactive 3-phase wizard (Propose → Review → Write) and non-interactive CLI flags mode.
- **`tests/test_generate_config.py`** — 95 unit tests covering all pure functions (BAM discovery, role detection, patient grouping, pairing, row generation, GATK resource discovery, config YAML building, TSV writing).
- **`README.md`** — full rewrite matching sm-alignment's documentation style: setup guide, config generator usage (interactive + CLI), configuration reference, HPC run instructions, pipeline architecture, tools & conda, development workflow.
- **`Makefile`** — added `scripts/generate_config.py` to `PY_FILES` so `make lint` and `make typecheck` cover it.

## Test plan

- [x] `pytest tests/test_generate_config.py -v` — 95 tests pass
- [x] `pytest tests/ -v -m "not dryrun"` — all 121 unit tests pass
- [x] `ruff check scripts/generate_config.py tests/test_generate_config.py` — lint clean
- [x] `mypy scripts/generate_config.py` — no type errors
- [ ] `python scripts/generate_config.py --bam-folder <path> --dry-run` — manual smoke test on real BAMs
- [ ] `python scripts/generate_config.py` — interactive walkthrough on cluster

🤖 Generated with [Claude Code](https://claude.com/claude-code)