### PR TITLE
feat: variant QC, PureCN integration, and Mutect2 bugfixes

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -25,6 +25,36 @@ Unified pipeline configuration. All paths are relative to the repository root.
 | `gatk_resources.af_only_gnomad` | Path to gnomAD allele frequency VCF |
 | `gatk_resources.common_biallelic_gnomad` | Path to gnomAD common biallelic VCF |
 
+### Mutect2 Parameters (`params.mutect2`)
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `genotype_germline_sites` | boolean | `true` | Emit germline sites (required for PureCN) |
+| `genotype_pon_sites` | boolean | `true` | Emit PoN sites (required for PureCN) |
+| `annotations` | array of strings | `[]` | Extra `--annotation` flags for Mutect2 |
+| `annotation_groups` | array of strings | `[]` | Extra `--annotation-group` flags for Mutect2 |
+| `extra` | string | `""` | Passthrough for any other Mutect2 flags |
+
+### QC Parameters (`params.bcftools_stats`)
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `extra` | string | `""` | Extra flags for `bcftools stats` |
+
+### PureCN Settings (`purecn`)
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `enabled` | boolean | `false` | Enable PureCN copy number analysis |
+| `genome` | string | `"hg38"` | PureCN genome identifier (`"hg19"` or `"hg38"`) |
+| `intervals_bed` | string | `""` | BED file with capture bait coordinates |
+| `normaldb` | string | `""` | Pre-built `normalDB.rds` (skip NormalDB.R if provided) |
+| `mapping_bias` | string | `""` | Pre-built `mapping_bias.rds` |
+| `snp_blacklist` | string | `""` | Optional simple repeats BED for SNP filtering |
+| `extra` | string | `""` | Extra PureCN.R arguments |
+| `seed` | integer | `123` | Random seed for PureCN |
+| `postoptimize` | boolean | `true` | Run PureCN post-optimization |
+
 ## `samples.tsv`
 
 Tab-separated sample metadata. Required columns:

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -61,8 +61,29 @@ scatter:
 # --- Tool-specific parameters (passthrough) ---
 params:
   mutect2:
-    extra: "--genotype-germline-sites true --genotype-pon-sites true"
+    # PureCN-compatible defaults (emit germline + PoN sites)
+    genotype_germline_sites: true
+    genotype_pon_sites: true
+    # Optional: additional Mutect2 annotations
+    annotations: []
+    annotation_groups: []
+    # Passthrough for any other Mutect2 flags
+    extra: ""
   freebayes:
     extra: "--min-coverage 20 --limit-coverage 500 --use-best-n-alleles 4 --standard-filters"
   bcftools_norm:
     extra: "-m-any --force -a --atom-overlaps ."
+  bcftools_stats:
+    extra: ""
+
+# --- PureCN settings (optional, for copy number analysis) ---
+purecn:
+  enabled: false  # opt-in, not everyone needs CN analysis
+  genome: "hg38"  # hg19 | hg38
+  intervals_bed: ""  # BED file with capture bait coordinates
+  normaldb: ""  # Pre-built normalDB.rds (skip NormalDB.R if provided)
+  mapping_bias: ""  # Pre-built mapping_bias.rds
+  snp_blacklist: ""  # Optional: simple repeats BED for SNP filtering
+  extra: ""  # Extra PureCN.R arguments
+  seed: 123
+  postoptimize: true

--- a/profiles/default/config.v8+.yaml
+++ b/profiles/default/config.v8+.yaml
@@ -4,7 +4,6 @@
 # a separate --profile (e.g., profiles/bih/ or profiles/charite/).
 
 latency-wait: 60
-jobs: 20
 rerun-incomplete: true
 printshellcmds: true
 software-deployment-method:

--- a/profiles/default/config.v8+.yaml
+++ b/profiles/default/config.v8+.yaml
@@ -34,6 +34,12 @@ set-threads:
   merge_freebayes_vcfs: 12
   scatter_intervals_by_ns: 1
   split_intervals: 4
+  bcftools_stats_mutect2: 1
+  bcftools_stats_freebayes: 1
+  multiqc: 1
+  purecn_coverage: 1
+  purecn_normaldb: 1
+  purecn_run: 1
 
 set-resources:
   mutect2_call:
@@ -63,3 +69,21 @@ set-resources:
   merge_freebayes_vcfs:
     mem_mb: 16384
     runtime: 1440
+  bcftools_stats_mutect2:
+    mem_mb: 4000
+    runtime: 120
+  bcftools_stats_freebayes:
+    mem_mb: 4000
+    runtime: 120
+  multiqc:
+    mem_mb: 4000
+    runtime: 120
+  purecn_coverage:
+    mem_mb: 8000
+    runtime: 720
+  purecn_normaldb:
+    mem_mb: 16384
+    runtime: 1440
+  purecn_run:
+    mem_mb: 16384
+    runtime: 2880

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -47,8 +47,15 @@ def config_dict():
             + ["chrX", "chrY", "chrM"],
         },
         "params": {
-            "mutect2": {"extra": "--genotype-germline-sites true"},
+            "mutect2": {
+                "genotype_germline_sites": True,
+                "genotype_pon_sites": True,
+                "annotations": [],
+                "annotation_groups": [],
+                "extra": "",
+            },
             "freebayes": {"extra": "--min-coverage 20"},
             "bcftools_norm": {"extra": "-m-any --force"},
+            "bcftools_stats": {"extra": ""},
         },
     }

--- a/tests/test_generate_config.py
+++ b/tests/test_generate_config.py
@@ -664,6 +664,83 @@ class TestBuildConfigYaml:
         )
         assert "EDIT_ME" in content
 
+    def test_purecn_disabled_by_default(self, ref_data, gatk_resources):
+        content = _build_config_yaml(
+            "mutect2",
+            ref_data,
+            gatk_resources,
+            "/bams",
+            "/output",
+            "config/samples.tsv",
+            ".bam",
+            "chromosome",
+        )
+        assert "enabled: false" in content
+
+    def test_purecn_enabled(self, ref_data, gatk_resources):
+        content = _build_config_yaml(
+            "mutect2",
+            ref_data,
+            gatk_resources,
+            "/bams",
+            "/output",
+            "config/samples.tsv",
+            ".bam",
+            "chromosome",
+            purecn_enabled=True,
+            purecn_genome="hg38",
+            purecn_intervals_bed="/beds/targets.bed",
+        )
+        assert "enabled: true" in content
+        assert 'genome: "hg38"' in content
+        assert "targets.bed" in content
+
+    def test_purecn_with_normaldb(self, ref_data, gatk_resources):
+        content = _build_config_yaml(
+            "mutect2",
+            ref_data,
+            gatk_resources,
+            "/bams",
+            "/output",
+            "config/samples.tsv",
+            ".bam",
+            "chromosome",
+            purecn_enabled=True,
+            purecn_normaldb="/purecn/normalDB.rds",
+            purecn_mapping_bias="/purecn/mapping_bias.rds",
+        )
+        assert "normalDB.rds" in content
+        assert "mapping_bias.rds" in content
+
+    def test_mutect2_dedicated_fields(self, ref_data, gatk_resources):
+        content = _build_config_yaml(
+            "mutect2",
+            ref_data,
+            gatk_resources,
+            "/bams",
+            "/output",
+            "config/samples.tsv",
+            ".bam",
+            "chromosome",
+        )
+        assert "genotype_germline_sites: true" in content
+        assert "genotype_pon_sites: true" in content
+        assert "annotations: []" in content
+        assert "annotation_groups: []" in content
+
+    def test_bcftools_stats_section(self, ref_data, gatk_resources):
+        content = _build_config_yaml(
+            "mutect2",
+            ref_data,
+            gatk_resources,
+            "/bams",
+            "/output",
+            "config/samples.tsv",
+            ".bam",
+            "chromosome",
+        )
+        assert "bcftools_stats:" in content
+
 
 # ---------------------------------------------------------------------------
 # TestBuildSamplesDataframe

--- a/tests/test_schema_validation.py
+++ b/tests/test_schema_validation.py
@@ -58,6 +58,44 @@ class TestConfigSchema:
             jsonschema.validate(broken, config_schema)
 
 
+    def test_mutect2_genotype_germline_sites_boolean(self, config_dict, config_schema):
+        cfg = copy.deepcopy(config_dict)
+        cfg["params"]["mutect2"]["genotype_germline_sites"] = True
+        jsonschema.validate(cfg, config_schema)
+
+    def test_mutect2_genotype_germline_sites_rejects_string(
+        self, config_dict, config_schema
+    ):
+        cfg = copy.deepcopy(config_dict)
+        cfg["params"]["mutect2"]["genotype_germline_sites"] = "yes"
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(cfg, config_schema)
+
+    def test_mutect2_annotations_array(self, config_dict, config_schema):
+        cfg = copy.deepcopy(config_dict)
+        cfg["params"]["mutect2"]["annotations"] = [
+            "OrientationBiasReadCounts",
+            "StrandBiasBySample",
+        ]
+        jsonschema.validate(cfg, config_schema)
+
+    def test_purecn_enabled_boolean(self, config_dict, config_schema):
+        cfg = copy.deepcopy(config_dict)
+        cfg["purecn"] = {"enabled": True, "genome": "hg38"}
+        jsonschema.validate(cfg, config_schema)
+
+    def test_purecn_genome_validates_enum(self, config_dict, config_schema):
+        cfg = copy.deepcopy(config_dict)
+        cfg["purecn"] = {"enabled": True, "genome": "invalid"}
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(cfg, config_schema)
+
+    def test_purecn_seed_integer(self, config_dict, config_schema):
+        cfg = copy.deepcopy(config_dict)
+        cfg["purecn"] = {"enabled": False, "genome": "hg38", "seed": 42}
+        jsonschema.validate(cfg, config_schema)
+
+
 @pytest.mark.skipif(jsonschema is None, reason="jsonschema not installed")
 class TestSamplesSchema:
     def test_valid_sample(self, samples_schema):

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -25,6 +25,24 @@ include: "rules/common.smk"
 include: "rules/scatter.smk"
 include: "rules/mutect2.smk"
 include: "rules/freebayes.smk"
+include: "rules/qc.smk"
+include: "rules/purecn.smk"
+
+
+# -- Validation --------------------------------------------------------------
+if PURECN_ENABLED and CALLER in ("mutect2", "all"):
+    if not PURECN_INTERVALS_BED:
+        raise ValueError(
+            "PureCN is enabled but 'purecn.intervals_bed' is not set. "
+            "Provide a BED file with capture bait coordinates."
+        )
+    if not get_normal_bams() and not PURECN_NORMALDB:
+        raise ValueError(
+            "PureCN is enabled but no normal BAMs found in samples.tsv "
+            "and no pre-built normalDB provided (purecn.normaldb). "
+            "Either add normal BAMs to your sample sheet or provide a "
+            "pre-built normalDB.rds via the purecn.normaldb config field."
+        )
 
 
 # -- Target rule -------------------------------------------------------------

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -36,13 +36,21 @@ if PURECN_ENABLED and CALLER in ("mutect2", "all"):
             "PureCN is enabled but 'purecn.intervals_bed' is not set. "
             "Provide a BED file with capture bait coordinates."
         )
-    if not get_normal_bams() and not PURECN_NORMALDB:
-        raise ValueError(
-            "PureCN is enabled but no normal BAMs found in samples.tsv "
-            "and no pre-built normalDB provided (purecn.normaldb). "
-            "Either add normal BAMs to your sample sheet or provide a "
-            "pre-built normalDB.rds via the purecn.normaldb config field."
-        )
+    if not get_normal_bams():
+        if not PURECN_NORMALDB:
+            raise ValueError(
+                "PureCN is enabled but no normal BAMs found in samples.tsv "
+                "and no pre-built normalDB provided (purecn.normaldb). "
+                "Either add normal BAMs to your sample sheet or provide a "
+                "pre-built normalDB.rds via the purecn.normaldb config field."
+            )
+        if not PURECN_MAPPING_BIAS:
+            raise ValueError(
+                "PureCN is enabled with a pre-built normalDB but no "
+                "mapping_bias file provided (purecn.mapping_bias). "
+                "When using a pre-built normalDB without normal BAMs, "
+                "you must also provide the matching mapping_bias.rds file."
+            )
 
 
 # -- Target rule -------------------------------------------------------------

--- a/workflow/envs/multiqc.yaml
+++ b/workflow/envs/multiqc.yaml
@@ -1,0 +1,5 @@
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - multiqc=1.27

--- a/workflow/envs/purecn.yaml
+++ b/workflow/envs/purecn.yaml
@@ -1,0 +1,6 @@
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - bioconductor-purecn=2.12.0
+  - r-optparse=1.7.5

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -124,6 +124,15 @@ def get_normal_name(wildcards):
     return ""
 
 
+def get_normal_input_arg(wildcards):
+    """Return '-I normal.bam' arg or empty string for GATK Mutect2."""
+    row = samples_df.loc[wildcards.sample]
+    normal = row.get("normal_bam", "")
+    if normal and normal != "." and pd.notna(normal):
+        return f"-I {os.path.join(BAM_FOLDER, normal + BAM_EXT)}"
+    return ""
+
+
 def get_interval_arg(wildcards):
     """Return -L argument based on scatter mode and unit."""
     unit = wildcards.scatter_unit

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -5,9 +5,11 @@ import os
 import pandas as pd
 
 from rules.helpers import (
+    build_mutect2_extra_args as _build_mutect2_extra_args_impl,
     get_java_opts as _get_java_opts_impl,
     get_mutect2_samples as _get_mutect2_samples_impl,
     get_germline_samples as _get_germline_samples_impl,
+    get_normal_bam_basenames as _get_normal_bam_basenames_impl,
     get_unique_bam_basenames as _get_unique_bam_basenames_impl,
     has_matched_normal as _has_matched_normal_impl,
     get_scatter_units as _get_scatter_units_impl,
@@ -38,10 +40,18 @@ PON = GATK_RES.get("panel_of_normals", "")
 AF_GNOMAD = GATK_RES.get("af_only_gnomad", "")
 COMMON_GNOMAD = GATK_RES.get("common_biallelic_gnomad", "")
 
-# Tool params
-MUTECT2_EXTRA = config.get("params", {}).get("mutect2", {}).get("extra", "")
+# Tool params -- Mutect2 (dedicated fields + passthrough)
+_m2_params = config.get("params", {}).get("mutect2", {})
+MUTECT2_ALL_ARGS = _build_mutect2_extra_args_impl(
+    genotype_germline_sites=_m2_params.get("genotype_germline_sites", True),
+    genotype_pon_sites=_m2_params.get("genotype_pon_sites", True),
+    annotations=_m2_params.get("annotations", []),
+    annotation_groups=_m2_params.get("annotation_groups", []),
+    extra=_m2_params.get("extra", ""),
+)
 FREEBAYES_EXTRA = config.get("params", {}).get("freebayes", {}).get("extra", "")
 BCFTOOLS_NORM_EXTRA = config.get("params", {}).get("bcftools_norm", {}).get("extra", "")
+BCFTOOLS_STATS_EXTRA = config.get("params", {}).get("bcftools_stats", {}).get("extra", "")
 
 
 # -- Output subdirectories ---------------------------------------------------
@@ -53,6 +63,8 @@ MUTECT2_FILTERED_DIR = os.path.join(MUTECT2_DIR, "filtered")
 
 FREEBAYES_DIR = os.path.join(OUTPUT_DIR, "freebayes")
 FREEBAYES_SCATTER_DIR = os.path.join(FREEBAYES_DIR, "scattered")
+
+QC_DIR = os.path.join(OUTPUT_DIR, "qc")
 
 
 # -- Scatter units -----------------------------------------------------------
@@ -70,6 +82,10 @@ def get_germline_sample_list():
 
 def get_unique_bams():
     return _get_unique_bam_basenames_impl(samples_df)
+
+
+def get_normal_bams():
+    return _get_normal_bam_basenames_impl(samples_df)
 
 
 def has_normal(sample):
@@ -156,6 +172,39 @@ def get_normal_pileup(wildcards):
     return []
 
 
+# -- PureCN config -----------------------------------------------------------
+_purecn_cfg = config.get("purecn", {})
+PURECN_ENABLED = _purecn_cfg.get("enabled", False)
+PURECN_GENOME = _purecn_cfg.get("genome", "hg38")
+PURECN_DIR = os.path.join(OUTPUT_DIR, "purecn")
+PURECN_REF_DIR = os.path.join(PURECN_DIR, "reference")
+PURECN_COV_DIR = os.path.join(PURECN_DIR, "coverage")
+PURECN_RESULTS_DIR = os.path.join(PURECN_DIR, "results")
+PURECN_INTERVALS_BED = _purecn_cfg.get("intervals_bed", "")
+PURECN_NORMALDB = _purecn_cfg.get("normaldb", "")
+PURECN_MAPPING_BIAS = _purecn_cfg.get("mapping_bias", "")
+PURECN_SNP_BLACKLIST = _purecn_cfg.get("snp_blacklist", "")
+PURECN_EXTRA = _purecn_cfg.get("extra", "")
+PURECN_SEED = _purecn_cfg.get("seed", 123)
+PURECN_POSTOPTIMIZE = _purecn_cfg.get("postoptimize", True)
+
+
+# -- QC helpers --------------------------------------------------------------
+def get_qc_inputs():
+    """Return list of bcftools stats files for MultiQC."""
+    inputs = []
+    if CALLER in ("mutect2", "all"):
+        for sample in get_mutect2_sample_list():
+            inputs.append(
+                os.path.join(QC_DIR, "bcftools_stats", "mutect2", f"{sample}.stats.txt")
+            )
+    if CALLER in ("freebayes", "all"):
+        inputs.append(
+            os.path.join(QC_DIR, "bcftools_stats", "freebayes", "all_samples.stats.txt")
+        )
+    return inputs
+
+
 # -- Final output dispatcher -------------------------------------------------
 def get_final_outputs():
     """Return all expected final output files based on caller selection."""
@@ -165,4 +214,11 @@ def get_final_outputs():
             outputs.append(os.path.join(MUTECT2_FILTERED_DIR, f"{sample}.filtered.vcf.gz"))
     if CALLER in ("freebayes", "all"):
         outputs.append(os.path.join(FREEBAYES_DIR, "final_merged.vcf.gz"))
+    # PureCN outputs (Mutect2 samples only)
+    if PURECN_ENABLED and CALLER in ("mutect2", "all"):
+        for sample in get_mutect2_sample_list():
+            outputs.append(os.path.join(PURECN_RESULTS_DIR, sample, f"{sample}.csv"))
+    # QC report (always generated when there are outputs)
+    if outputs:
+        outputs.append(os.path.join(QC_DIR, "multiqc_report.html"))
     return outputs

--- a/workflow/rules/helpers.py
+++ b/workflow/rules/helpers.py
@@ -62,6 +62,41 @@ def get_scatter_units(
         return ["all"]
 
 
+def build_mutect2_extra_args(
+    genotype_germline_sites: bool = True,
+    genotype_pon_sites: bool = True,
+    annotations: list[str] | None = None,
+    annotation_groups: list[str] | None = None,
+    extra: str = "",
+) -> str:
+    """Build the complete Mutect2 extra arguments string.
+
+    Combines dedicated config fields with the passthrough ``extra`` string.
+    """
+    args: list[str] = []
+    if genotype_germline_sites:
+        args.append("--genotype-germline-sites true")
+    if genotype_pon_sites:
+        args.append("--genotype-pon-sites true")
+    for ann in annotations or []:
+        args.append(f"--annotation {ann}")
+    for grp in annotation_groups or []:
+        args.append(f"--annotation-group {grp}")
+    if extra:
+        args.append(extra)
+    return " ".join(args)
+
+
+def get_normal_bam_basenames(samples_df: pd.DataFrame) -> list[str]:
+    """Return sorted basenames of all normal BAMs (for NormalDB)."""
+    normals: set[str] = set()
+    for _, row in samples_df.iterrows():
+        normal = row.get("normal_bam", "")
+        if normal and normal != "." and pd.notna(normal):
+            normals.add(normal)
+    return sorted(normals)
+
+
 def build_freebayes_params(extra: str) -> str:
     """Return the FreeBayes extra params string (passthrough from config)."""
     return extra

--- a/workflow/rules/mutect2.smk
+++ b/workflow/rules/mutect2.smk
@@ -30,6 +30,7 @@ rule mutect2_call:
         f1r2=temp(os.path.join(MUTECT2_SCATTER_DIR, "{sample}_{scatter_unit}.f1r2.tar.gz")),
     params:
         normal_arg=get_normal_name,
+        normal_input_arg=get_normal_input_arg,
         interval_arg=get_interval_arg,
         java_opts=get_java_opts,
         extra=MUTECT2_ALL_ARGS,
@@ -48,6 +49,7 @@ rule mutect2_call:
         gatk --java-options '{params.java_opts}' Mutect2 \
             -R {input.reference} \
             -I {input.tumor_bam} \
+            {params.normal_input_arg} \
             {params.normal_arg} \
             --germline-resource {input.gnomad} \
             --panel-of-normals {input.pon} \

--- a/workflow/rules/mutect2.smk
+++ b/workflow/rules/mutect2.smk
@@ -32,7 +32,7 @@ rule mutect2_call:
         normal_arg=get_normal_name,
         interval_arg=get_interval_arg,
         java_opts=get_java_opts,
-        extra=MUTECT2_EXTRA,
+        extra=MUTECT2_ALL_ARGS,
     retries: 2
     resources:
         mem_mb=lambda wildcards, attempt: 17600 * attempt,

--- a/workflow/rules/purecn.smk
+++ b/workflow/rules/purecn.smk
@@ -1,0 +1,177 @@
+"""PureCN copy number analysis rules.
+
+Implements the PureCN pipeline for tumor purity, ploidy, and allele-specific
+copy number estimation. Only active when purecn.enabled is true in config.
+Requires Mutect2 caller (tumor_only or tumor_normal samples).
+"""
+
+
+if PURECN_ENABLED:
+
+    rule purecn_intervals:
+        """Generate optimised interval file for PureCN (one-time)."""
+        localrule: True
+        input:
+            bed=PURECN_INTERVALS_BED,
+            ref=REF,
+        output:
+            intervals=os.path.join(PURECN_REF_DIR, "intervals.txt"),
+        params:
+            genome=PURECN_GENOME,
+        conda:
+            "../envs/purecn.yaml"
+        log:
+            os.path.join(LOG_DIR, "purecn_intervals/intervals.log"),
+        shell:
+            r"""
+            PURECN=$(Rscript -e 'cat(system.file("extdata", package = "PureCN"))')
+
+            Rscript "$PURECN"/IntervalFile.R \
+                --infile {input.bed} \
+                --fasta {input.ref} \
+                --outfile {output.intervals} \
+                --offtarget \
+                --genome {params.genome} \
+                2> {log}
+            """
+
+    rule purecn_coverage:
+        """Compute GC-normalised coverage for a BAM (per unique BAM)."""
+        input:
+            bam=lambda wc: os.path.join(BAM_FOLDER, wc.bam_basename + BAM_EXT),
+            intervals=os.path.join(PURECN_REF_DIR, "intervals.txt"),
+        output:
+            coverage=os.path.join(
+                PURECN_COV_DIR, "{bam_basename}_coverage_loess.txt.gz"
+            ),
+        params:
+            outdir=PURECN_COV_DIR,
+        retries: 2
+        resources:
+            mem_mb=lambda wildcards, attempt: 8000 * attempt,
+            runtime=lambda wildcards, attempt: 720 * attempt,
+        conda:
+            "../envs/purecn.yaml"
+        log:
+            os.path.join(LOG_DIR, "purecn_coverage/{bam_basename}.log"),
+        benchmark:
+            os.path.join(LOG_DIR, "benchmarks/purecn_coverage/{bam_basename}.tsv")
+        shell:
+            r"""
+            PURECN=$(Rscript -e 'cat(system.file("extdata", package = "PureCN"))')
+
+            Rscript "$PURECN"/Coverage.R \
+                --bam {input.bam} \
+                --intervals {input.intervals} \
+                --outdir {params.outdir} \
+                2> {log}
+            """
+
+    rule purecn_normaldb:
+        """Build normal database from normal BAM coverages (one-time)."""
+        input:
+            coverages=lambda wc: [
+                os.path.join(PURECN_COV_DIR, f"{bn}_coverage_loess.txt.gz")
+                for bn in get_normal_bams()
+            ],
+        output:
+            normaldb=os.path.join(PURECN_REF_DIR, "normalDB.rds"),
+            bias=os.path.join(PURECN_REF_DIR, "mapping_bias.rds"),
+        params:
+            outdir=PURECN_REF_DIR,
+            genome=PURECN_GENOME,
+        retries: 2
+        resources:
+            mem_mb=lambda wildcards, attempt: 16384 * attempt,
+            runtime=lambda wildcards, attempt: 1440 * attempt,
+        conda:
+            "../envs/purecn.yaml"
+        log:
+            os.path.join(LOG_DIR, "purecn_normaldb/normaldb.log"),
+        benchmark:
+            os.path.join(LOG_DIR, "benchmarks/purecn_normaldb/normaldb.tsv")
+        shell:
+            r"""
+            PURECN=$(Rscript -e 'cat(system.file("extdata", package = "PureCN"))')
+
+            Rscript "$PURECN"/NormalDB.R \
+                --coveragefiles {input.coverages} \
+                --outdir {params.outdir} \
+                --genome {params.genome} \
+                2> {log}
+            """
+
+    def _get_purecn_normaldb(wildcards):
+        """Return pre-built normalDB or pipeline-generated one."""
+        if PURECN_NORMALDB:
+            return PURECN_NORMALDB
+        return os.path.join(PURECN_REF_DIR, "normalDB.rds")
+
+    def _get_purecn_mapping_bias(wildcards):
+        """Return pre-built mapping bias file or pipeline-generated one."""
+        if PURECN_MAPPING_BIAS:
+            return PURECN_MAPPING_BIAS
+        return os.path.join(PURECN_REF_DIR, "mapping_bias.rds")
+
+    def _get_purecn_snp_blacklist_arg(wildcards):
+        """Return --snpblacklist arg or empty string."""
+        if PURECN_SNP_BLACKLIST:
+            return f"--snpblacklist {PURECN_SNP_BLACKLIST}"
+        return ""
+
+    rule purecn_run:
+        """Run PureCN purity/ploidy estimation for a Mutect2 sample."""
+        input:
+            coverage=lambda wc: os.path.join(
+                PURECN_COV_DIR,
+                samples_df.loc[wc.sample, "tumor_bam"] + "_coverage_loess.txt.gz",
+            ),
+            vcf=os.path.join(MUTECT2_FILTERED_DIR, "{sample}.filtered.vcf.gz"),
+            stats=os.path.join(MUTECT2_MERGED_DIR, "{sample}.vcf.gz.stats"),
+            intervals=os.path.join(PURECN_REF_DIR, "intervals.txt"),
+            normaldb=_get_purecn_normaldb,
+            mapping_bias=_get_purecn_mapping_bias,
+        output:
+            rds=os.path.join(PURECN_RESULTS_DIR, "{sample}", "{sample}.rds"),
+            csv=os.path.join(PURECN_RESULTS_DIR, "{sample}", "{sample}.csv"),
+            loh=os.path.join(
+                PURECN_RESULTS_DIR, "{sample}", "{sample}_loh.csv"
+            ),
+        params:
+            outdir=lambda wc: os.path.join(PURECN_RESULTS_DIR, wc.sample),
+            genome=PURECN_GENOME,
+            seed=PURECN_SEED,
+            postoptimize="--postoptimize" if PURECN_POSTOPTIMIZE else "",
+            snp_blacklist=_get_purecn_snp_blacklist_arg,
+            extra=PURECN_EXTRA,
+        retries: 2
+        resources:
+            mem_mb=lambda wildcards, attempt: 16384 * attempt,
+            runtime=lambda wildcards, attempt: 2880 * attempt,
+        conda:
+            "../envs/purecn.yaml"
+        log:
+            os.path.join(LOG_DIR, "purecn_run/{sample}.log"),
+        benchmark:
+            os.path.join(LOG_DIR, "benchmarks/purecn_run/{sample}.tsv")
+        shell:
+            r"""
+            PURECN=$(Rscript -e 'cat(system.file("extdata", package = "PureCN"))')
+
+            Rscript "$PURECN"/PureCN.R \
+                --out {params.outdir}/{wildcards.sample} \
+                --tumor {input.coverage} \
+                --sampleid {wildcards.sample} \
+                --vcf {input.vcf} \
+                --statsfile {input.stats} \
+                --normaldb {input.normaldb} \
+                --mappingbiasfile {input.mapping_bias} \
+                --intervals {input.intervals} \
+                --genome {params.genome} \
+                --force \
+                --seed {params.seed} \
+                {params.postoptimize} \
+                {params.snp_blacklist} \
+                {params.extra} \
+                2> {log}
+            """

--- a/workflow/rules/qc.smk
+++ b/workflow/rules/qc.smk
@@ -1,0 +1,85 @@
+"""Variant calling quality control rules.
+
+Generates per-sample bcftools stats and an aggregated MultiQC report.
+"""
+
+
+rule bcftools_stats_mutect2:
+    """Per-sample variant statistics for Mutect2 filtered VCFs."""
+    input:
+        vcf=os.path.join(MUTECT2_FILTERED_DIR, "{sample}.filtered.vcf.gz"),
+        ref=REF,
+    output:
+        stats=os.path.join(QC_DIR, "bcftools_stats", "mutect2", "{sample}.stats.txt"),
+    params:
+        extra=BCFTOOLS_STATS_EXTRA,
+    conda:
+        "../envs/bcftools.yaml"
+    log:
+        os.path.join(LOG_DIR, "bcftools_stats/mutect2/{sample}.log"),
+    benchmark:
+        os.path.join(LOG_DIR, "benchmarks/bcftools_stats/mutect2/{sample}.tsv")
+    shell:
+        r"""
+        bcftools stats \
+            -s- \
+            -F {input.ref} \
+            {params.extra} \
+            {input.vcf} \
+            > {output.stats} \
+            2> {log}
+        """
+
+
+rule bcftools_stats_freebayes:
+    """Variant statistics for FreeBayes merged VCF."""
+    input:
+        vcf=os.path.join(FREEBAYES_DIR, "final_merged.vcf.gz"),
+        ref=REF,
+    output:
+        stats=os.path.join(
+            QC_DIR, "bcftools_stats", "freebayes", "all_samples.stats.txt"
+        ),
+    params:
+        extra=BCFTOOLS_STATS_EXTRA,
+    conda:
+        "../envs/bcftools.yaml"
+    log:
+        os.path.join(LOG_DIR, "bcftools_stats/freebayes/all_samples.log"),
+    benchmark:
+        os.path.join(LOG_DIR, "benchmarks/bcftools_stats/freebayes/all_samples.tsv")
+    shell:
+        r"""
+        bcftools stats \
+            -s- \
+            -F {input.ref} \
+            {params.extra} \
+            {input.vcf} \
+            > {output.stats} \
+            2> {log}
+        """
+
+
+rule multiqc:
+    """Aggregate all QC stats into a single MultiQC HTML report."""
+    input:
+        stats=get_qc_inputs(),
+    output:
+        html=os.path.join(QC_DIR, "multiqc_report.html"),
+        data=directory(os.path.join(QC_DIR, "multiqc_data")),
+    params:
+        use_input_files_only=True,
+    conda:
+        "../envs/multiqc.yaml"
+    log:
+        os.path.join(LOG_DIR, "multiqc/multiqc.log"),
+    shell:
+        r"""
+        multiqc \
+            --force \
+            --no-data-dir \
+            --outdir $(dirname {output.html}) \
+            --filename $(basename {output.html}) \
+            {input.stats} \
+            2> {log}
+        """

--- a/workflow/rules/qc.smk
+++ b/workflow/rules/qc.smk
@@ -37,9 +37,7 @@ rule bcftools_stats_freebayes:
         vcf=os.path.join(FREEBAYES_DIR, "final_merged.vcf.gz"),
         ref=REF,
     output:
-        stats=os.path.join(
-            QC_DIR, "bcftools_stats", "freebayes", "all_samples.stats.txt"
-        ),
+        stats=os.path.join(QC_DIR, "bcftools_stats", "freebayes", "all_samples.stats.txt"),
     params:
         extra=BCFTOOLS_STATS_EXTRA,
     conda:
@@ -67,8 +65,6 @@ rule multiqc:
     output:
         html=os.path.join(QC_DIR, "multiqc_report.html"),
         data=directory(os.path.join(QC_DIR, "multiqc_data")),
-    params:
-        use_input_files_only=True,
     conda:
         "../envs/multiqc.yaml"
     log:
@@ -77,7 +73,6 @@ rule multiqc:
         r"""
         multiqc \
             --force \
-            --no-data-dir \
             --outdir $(dirname {output.html}) \
             --filename $(basename {output.html}) \
             {input.stats} \

--- a/workflow/schemas/config.schema.yaml
+++ b/workflow/schemas/config.schema.yaml
@@ -81,9 +81,80 @@ properties:
     properties:
       mutect2:
         type: object
+        properties:
+          genotype_germline_sites:
+            type: boolean
+            default: true
+            description: "Emit germline sites (required for PureCN)."
+          genotype_pon_sites:
+            type: boolean
+            default: true
+            description: "Emit PoN sites (required for PureCN)."
+          annotations:
+            type: array
+            items:
+              type: string
+            default: []
+            description: "Extra --annotation flags for Mutect2."
+          annotation_groups:
+            type: array
+            items:
+              type: string
+            default: []
+            description: "Extra --annotation-group flags for Mutect2."
+          extra:
+            type: string
+            default: ""
       freebayes:
         type: object
       bcftools_norm:
         type: object
+      bcftools_stats:
+        type: object
+        properties:
+          extra:
+            type: string
+            default: ""
+
+  purecn:
+    type: object
+    properties:
+      enabled:
+        type: boolean
+        default: false
+        description: "Enable PureCN copy number analysis."
+      genome:
+        type: string
+        enum: ["hg19", "hg38"]
+        default: "hg38"
+        description: "PureCN genome identifier."
+      intervals_bed:
+        type: string
+        default: ""
+        description: "BED file with capture bait coordinates."
+      normaldb:
+        type: string
+        default: ""
+        description: "Pre-built normalDB.rds (skip NormalDB.R if provided)."
+      mapping_bias:
+        type: string
+        default: ""
+        description: "Pre-built mapping_bias.rds."
+      snp_blacklist:
+        type: string
+        default: ""
+        description: "Optional simple repeats BED for SNP filtering."
+      extra:
+        type: string
+        default: ""
+        description: "Extra PureCN.R arguments."
+      seed:
+        type: integer
+        default: 123
+        description: "Random seed for PureCN."
+      postoptimize:
+        type: boolean
+        default: true
+        description: "Run PureCN post-optimization."
 
 required: [caller, ref, paths, bam, scatter]


### PR DESCRIPTION
## Summary

- **Variant QC** (issue #6): Add per-sample `bcftools stats` and aggregated MultiQC HTML report as automatic pipeline outputs
- **PureCN integration** (issue #9): Full copy number analysis pipeline (intervals, coverage, normalDB, per-sample purity/ploidy), opt-in via `purecn.enabled: true`
- **Dedicated Mutect2 config fields** (issue #9): Replace `extra` string with schema-validated `genotype_germline_sites`, `genotype_pon_sites`, `annotations`, `annotation_groups` fields
- **Fix missing normal BAM `-I` flag** (issue #14): Add `-I normal.bam` to Mutect2 call in tumor-normal mode, fixing "Sample not in BAM header" error
- **Fix jobs concurrency cap** (issue #15): Remove `jobs: 20` from workflow profile so cluster profiles control concurrency

## New files

- `workflow/rules/qc.smk` — bcftools_stats + multiqc rules
- `workflow/rules/purecn.smk` — 4 PureCN rules (intervals, coverage, normaldb, run)
- `workflow/envs/multiqc.yaml` — MultiQC 1.27
- `workflow/envs/purecn.yaml` — PureCN 2.12.0 + r-optparse

## Key design decisions

- PureCN is **off by default** (`purecn.enabled: false`), only runs on Mutect2 samples
- Startup validation errors early if PureCN enabled without intervals BED or without normals/pre-built normalDB
- Config generator updated with `--purecn` CLI flags and interactive prompts
- QC report is always generated when there are caller outputs

## Test plan

- [x] `pytest tests/ -v` — 148/148 passed
- [x] `ruff check` — clean
- [x] `ruff format --check` — clean
- [x] `mypy` — clean
- [ ] Dry-run with PureCN disabled
- [ ] Dry-run with PureCN enabled
- [ ] Verify tumor-normal Mutect2 call includes `-I normal.bam`

Closes #6, closes #9, closes #14, closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)